### PR TITLE
Fix: Update Gemfile.lock after dependency changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/RobertoJBeltran/jekyll-terser.git
-  revision: 1085bf66d692799af09fe39f8162a1e6e42a3cc4
-  specs:
-    jekyll-terser (0.2.3)
-      jekyll (>= 0.10.0)
-      terser (>= 1.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -78,7 +70,6 @@ GEM
     ffi (1.17.1-x86_64-linux-musl)
     forwardable (1.3.3)
     forwardable-extended (2.6.0)
-    gemoji (4.1.0)
     google-protobuf (4.30.1)
       bigdecimal
       rake (>= 13)
@@ -94,9 +85,6 @@ GEM
     google-protobuf (4.30.1-x86_64-linux)
       bigdecimal
       rake (>= 13)
-    html-pipeline (2.14.3)
-      activesupport (>= 2)
-      nokogiri (>= 1.4)
     htmlcompressor (0.4.0)
     http_parser.rb (0.8.0)
     httparty (0.22.0)
@@ -158,16 +146,14 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-tabs (1.2.1)
       jekyll (>= 3.0, < 5.0)
+    jekyll-terser (1.0.0)
+      jekyll (~> 4.4)
+      terser (~> 1.2)
     jekyll-toc (0.19.0)
       jekyll (>= 3.9)
       nokogiri (~> 1.12)
-    jekyll-twitter-plugin (2.1.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    jemoji (0.13.0)
-      gemoji (>= 3, < 5)
-      html-pipeline (~> 2.2)
-      jekyll (>= 3.0, < 5.0)
     json (2.10.2)
     json-minify (0.0.3)
       json (> 0)
@@ -291,10 +277,8 @@ DEPENDENCIES
   jekyll-scholar
   jekyll-sitemap
   jekyll-tabs
-  jekyll-terser!
+  jekyll-terser (~> 1.0.0)
   jekyll-toc
-  jekyll-twitter-plugin
-  jemoji
   observer
   ostruct
 


### PR DESCRIPTION
I regenerated Gemfile.lock by running 'bundle install' to reflect the recent updates to jekyll-terser and removal of other gems. This should resolve the CI build failure.