### PR TITLE
Rework the Möbius blog series + project page

### DIFF
--- a/_posts/2026-04-26-mobius-an-app-that-builds-itself.md
+++ b/_posts/2026-04-26-mobius-an-app-that-builds-itself.md
@@ -32,14 +32,18 @@ deploys in about three minutes.</li>
 
 </details>
 
+A Möbius strip is a surface with no inside or outside and no beginning
+or end. That is the idea behind Möbius, an agent that loops back on
+itself, building the tools you use and improving them as it goes.
+
 ## You grow it from a chat input
 
 Möbius starts as almost nothing, a chat on one side and an empty
-canvas on the other. File upload and scheduled jobs have to be added;
-so does the notifications button. The agent can rewrite the thing it runs inside,
-so you grow it. Ask for file upload and it builds file upload. Ask for
-an app and one appears on the canvas. You end up with the shell you
-asked for.
+canvas on the other. Because the agent can rewrite the thing it runs
+inside, you grow it from there. File upload and scheduled jobs have to
+be added; so does the notifications button. Ask for file upload and it
+builds file upload. Ask for an app and one appears on the canvas. You
+end up with the shell you asked for.
 
 One of those moments looked like this, end to end. I sent a
 deliberately ordinary prompt. _"I'd like to send files and images along
@@ -50,12 +54,11 @@ storage, drag-and-drop, and image rendering.
 
 ## You can break it
 
-The same power cuts both ways. Tell the agent to delete an app and it
-deletes it. Tell it to rip out a feature and the feature is gone. You
-can repaint the shell until the composer is hidden or restructure the
-navigation until the drawer is unreachable. That comes with the
-territory. An interface you can grow in any direction can also break in
-any direction.
+The same power works against you too. Tell the agent to delete an app
+and it deletes it. Tell it to rip out a feature and the feature is
+gone. You can repaint the shell until the composer is hidden or
+restructure the navigation until the drawer is unreachable. Anything
+you can build, you can also break.
 
 Recovery keeps that cheap. `/recover` is a separate page served outside
 the editable shell, rendered straight from the server, so it loads even
@@ -75,21 +78,15 @@ I want software that bends to you.
 Most software asks you to adapt to it. Over time, AI assistants make
 this worse. Preferences leak between tasks, memory accumulates in the
 wrong places, and the thing that was helpful yesterday becomes an
-invisible constraint today. The model in front of you is usually
-capable of writing the tool you want. The product around it still stops
-at talking about the tool. You ask for a workflow and get advice. You
-describe a tool and get a mockup, a snippet, or a plan. The
-assistant stays on one side of the glass.
+invisible constraint today. The model in front of you can usually write
+the tool you want, but the product around it stops at talking about it.
+Ask for a workflow and you get advice; describe a tool and you get a
+mockup or a plan. It never crosses over into building the thing.
 
-Möbius puts the assistant inside the product around it. Asking for a
+Möbius puts the assistant inside the product. Asking for a
 tool, using it, and correcting it happen in one place. The platform has
 to be editable for that to work. If the agent stops at describing the
 work, you still have to carry the system in your head.
-
-The name is from Möbius strips. Each app the agent builds shows up in
-the shell the chat lives in, and the next conversation happens with
-that app available. A different version of the same chat once wrote the
-shell the chat runs in.
 
 ## How it works
 
@@ -270,8 +267,8 @@ it shows. I had four directions in mind:
   start from structured memory and skip a full scan of every
   conversation.
 - **Reflection.** A scheduled background pass that consolidates and
-  reorganises the graph while you are away, the self-hosted version of
-  an agent that tidies up after itself on its own time.
+  reorganises the graph while you are away, so the agent maintains its
+  own memory on its own schedule.
 - **Discretion.** Noticing stale apps and suggesting something worth
   learning before it interrupts, with the user's interest as the
   constraint.
@@ -279,8 +276,9 @@ it shows. I had four directions in mind:
   sure how to ship. An agent that notices you have been reading
   distributed-systems papers three Tuesdays in a row and builds you
   a swipe-style recommender on its own. Most products
-  in this space are tuned to maximise engagement; I want a system that
-  shows up because it knows you and respects your attention.
+  in this space are tuned to maximise engagement. I want one that
+  surfaces a suggestion only when it has a real reason to, and
+  otherwise leaves you alone.
 
 When this was written, all four were still future work. Since then, the
 Memory graph and Reflection have shipped, covered in a [later post in
@@ -301,7 +299,7 @@ The source is on [GitHub](https://github.com/mobius-os/mobius), the
 project page is [here]({{ '/mobius/' | relative_url }}), and the
 README's deploy button gets you a working instance in about three
 minutes. It runs for roughly five dollars a month on hosting you
-control, against your own Claude or Codex account, and your data stays
-on the machine you deployed it to. The free Codex plan is already
+control, signing in with your own Claude or Codex account, and your
+data stays on the machine you deployed it to. The free Codex plan is already
 enough to do a lot. I would love to know what you build with it, and
 what you change _around_ what you build.

--- a/_posts/2026-04-26-mobius-an-app-that-builds-itself.md
+++ b/_posts/2026-04-26-mobius-an-app-that-builds-itself.md
@@ -21,10 +21,11 @@ conversation.</li>
 <li><strong>Capabilities</strong> (file upload, notifications,
 settings panels) are candidates for upstreaming so the next install
 inherits them.</li>
-<li><strong>Presentation</strong> (your theme, layout, fonts) lives
-only on your volume and stays yours.</li>
-<li><strong><code>/recover</code></strong> resets the shell when
-the agent paints itself into a corner.</li>
+<li><strong>Presentation</strong> (your theme, layout, fonts) stays
+on your volume and remains yours.</li>
+<li><strong><code>/recover</code></strong> is a separate recovery
+page that brings the instance back when the agent paints itself into a
+corner.</li>
 <li>Source on <a href="https://github.com/mobius-os/mobius">GitHub</a>;
 deploys in about three minutes.</li>
 </ul>
@@ -34,77 +35,74 @@ deploys in about three minutes.</li>
 ## You grow it from a chat input
 
 Möbius starts as almost nothing, a chat on one side and an empty
-canvas on the other. No file upload, no scheduled jobs panel, no
-notifications button. What makes that interesting is that the agent can rewrite the
-thing it runs inside. So you grow it. Ask for file upload and it
-builds file upload. Ask for a new look and it restyles itself. Ask for
-an app and one appears on the canvas. The shell you end up with is the
-one you talked into being.
+canvas on the other. File upload and scheduled jobs have to be added;
+so does the notifications button. The agent can rewrite the thing it runs inside,
+so you grow it. Ask for file upload and it builds file upload. Ask for
+an app and one appears on the canvas. You end up with the shell you
+asked for.
 
-Here is one of those moments, end to end. I sent a deliberately
-ordinary prompt. _"I'd like to send files and images along with my
-messages, pictures of stuff I want to talk about, the occasional
-document. Can you add file upload to the chat?"_ One conversation
-later there was a backend route, message storage, drag-and-drop, and
-image rendering, none of which existed when I asked.
+One of those moments looked like this, end to end. I sent a
+deliberately ordinary prompt. _"I'd like to send files and images along
+with my messages, pictures of stuff I want to talk about, the
+occasional document. Can you add file upload to the chat?"_ One
+conversation later the agent had added a backend route, message
+storage, drag-and-drop, and image rendering.
 
-## The flip side: you can break it
+## You can break it
 
 The same power cuts both ways. Tell the agent to delete an app and it
 deletes it. Tell it to rip out a feature and the feature is gone. You
-can repaint the shell until the composer is hidden, restructure the
-navigation until the drawer is unreachable, paint yourself into a
-corner. That is not a flaw. It is the point. An interface you can
-grow in any direction is, by construction, an interface you can also
-break.
+can repaint the shell until the composer is hidden or restructure the
+navigation until the drawer is unreachable. That comes with the
+territory. An interface you can grow in any direction can also break in
+any direction.
 
-What makes that safe is that breaking is cheap to undo. `/recover`
-bounds the blast radius. It resets the shell to its seeded baseline
-while keeping your chats, your apps, and your data. It renders from a
-separate server-side path the agent does not edit, so it survives
-even a shell rewrite that hides everything else. Grow in any
-direction, break it, recover, try again. The goal is maximal
-personalization, software that bends to you instead of the other way
-around.
+Recovery keeps that cheap. `/recover` is a separate page served outside
+the editable shell, rendered straight from the server, so it loads even
+when the shell it would normally live in is broken. From there a
+recovery chat can reset the shell to its seeded baseline, roll back to a
+backup, reinstall an app, or patch whatever broke, then restart, all
+while keeping your chats, your apps, and your data. That lets you
+break it, recover, and try again.
+
+The rest of this series stays with that trade. The agent can touch
+the apps, the interface, and the data on your own machine because that
+lets it be genuinely useful, and recovery keeps the cost close to zero.
+I want software that bends to you.
 
 ## Why I built this
 
-Most software asks you to adapt to it. AI assistants make this worse
-with time: preferences leak between tasks, memory accumulates in the
-wrong places, the thing that was helpful yesterday becomes an
+Most software asks you to adapt to it. Over time, AI assistants make
+this worse. Preferences leak between tasks, memory accumulates in the
+wrong places, and the thing that was helpful yesterday becomes an
 invisible constraint today. The model in front of you is usually
-capable of writing the tool you want, but the product around it can
-only talk about the tool. You ask for a workflow and get advice. You
+capable of writing the tool you want. The product around it still stops
+at talking about the tool. You ask for a workflow and get advice. You
 describe a tool and get a mockup, a snippet, or a plan. The
 assistant stays on one side of the glass.
 
-The premise of Möbius is to put it on the other side, to shorten the
-distance between wanting, making, using, and correcting until they
-happen in one place. Requests become software, software becomes
-context, the next request lands somewhere sharper. The platform has
-to be editable for that to work. If the agent can only talk about
-the work, you still have to carry the system in your head.
+Möbius puts the assistant inside the product around it. Asking for a
+tool, using it, and correcting it happen in one place. The platform has
+to be editable for that to work. If the agent stops at describing the
+work, you still have to carry the system in your head.
 
-The name is from Möbius strips. Each app the agent builds does not
-sit somewhere external; it lands in the shell the chat lives in, and
-becomes part of the surface the next conversation happens on. The
-shell the chat runs in was, once, written by a different version of
-the same chat.
+The name is from Möbius strips. Each app the agent builds shows up in
+the shell the chat lives in, and the next conversation happens with
+that app available. A different version of the same chat once wrote the
+shell the chat runs in.
 
 ## How it works
 
-The most obvious adaptive surface is the apps the agent builds. The
-interesting surface is everything around them, and it splits along a
-useful axis: **capabilities** (general features like file upload or
-notifications, candidates for upstreaming so the next install
-inherits them) and **presentation** (your theme, layout, fonts,
-which live only on your volume and stay yours). The harness treats
-those two stacks differently.
+Apps are the obvious adaptive surface. The surrounding shell matters
+too, and the harness separates **capabilities**
+(general features like file upload or notifications, candidates for
+upstreaming so the next install inherits them) from **presentation**
+(your theme, layout, fonts, which stay confined to your volume and
+stay yours).
 
-### Capabilities: the part that grows the platform
+### Capabilities grow the platform
 
-Walk through that file-upload chat from the top. The order is the
-point.
+Walk through that file-upload chat from the top, in order.
 
 <figure class="shot-row shot-row--flow">
   <div class="shot">
@@ -133,14 +131,14 @@ point.
   The build starts from an empty composer. The agent checks the
   codebase, surfaces three real decisions (file types, affordances,
   size cap), then writes the endpoint, the schema, the picker, and the
-  paperclip, none of which existed when I asked. By the end of the same
-  chat I attach the Möbius logo and the agent on the other side reads it
-  back. One conversation, from empty composer to working feature.
+  paperclip. By the end of the same chat I attach the Möbius logo and
+  the agent on the other side reads it back. One conversation, from
+  empty composer to working feature.
 </div>
 
-File upload is one capability the agent can build. The same loop
-produces apps, too, actual mini-applications that land on the canvas
-next to the chat and persist there.
+File upload is one capability the agent can build. The same loop also
+produces actual mini-applications that appear on the canvas next to the
+chat and persist there.
 
 <figure style="text-align: center; margin: 2rem auto;">
   <video src="{{ '/assets/img/mobius/apps-cycle.mp4' | relative_url }}" width="280" autoplay loop muted playsinline style="border-radius: 0.75rem; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);">
@@ -150,34 +148,34 @@ next to the chat and persist there.
     A few of the apps Möbius has built me, each from a single
     prompt: a live ISS tracker, a Brazil trip planner, a daily
     news digest, a Hacker News dashboard, an earthquake monitor, a
-    habit tracker, and a drum machine. The agent wrote the JSX,
-    compiled it, mounted it, and the app lives in the same shell
-    the chat does.
+    habit tracker, and a drum machine. The agent wrote the JSX and
+    mounted the compiled app in the same shell the chat uses.
   </figcaption>
 </figure>
 
-This is how general capabilities land (notifications, scheduled
-jobs, a web-search button, voice mode, a richer settings panel). The
-agent builds it when you ask. A second loop sits above the first, a
-harness that watches the inner agent and periodically asks _was this
-change generally useful, or was it just for me?_ The generally useful
-diffs become candidates for upstreaming into the shipped image, a
-promotion step I still review.
+General capabilities get added this way too. Notifications, scheduled
+jobs, a web-search button, voice mode, and a richer settings panel all
+fit the same path. The agent builds the feature when you ask. A second
+loop sits above the first, a harness that watches the inner agent and
+periodically asks
+_was this change generally useful, or specific to my instance?_ The
+generally useful diffs become candidates for upstreaming into the
+shipped image, a promotion step I still review.
 
-### Presentation: the part that stays yours
+### Presentation stays yours
 
-Capabilities are general; _taste_ is the opposite. The shell ships
-with one default theme, but the same agent that built file upload can
-rewrite the CSS, swap fonts, add background animation, restructure
-the layout, and that diff lives only on your volume. A redeploy can
-ship you the new file-upload feature without trampling your
-wood-paneled reading-room theme, because the two changes live in
-different layers.
+General capabilities can move upstream. _Taste_ belongs to the
+instance. The shell ships with one default theme. The same agent that
+built file upload can rewrite the CSS, swap fonts, add background
+animation, restructure the layout, and keep that diff confined to your
+volume. A redeploy can
+ship you the new file-upload feature while your wood-paneled reading-room
+theme stays put, because the two changes live in different layers.
 
-The cheap-to-vary axis is visual. Ask the agent to restyle the whole
+Visual changes are cheap to vary. Ask the agent to restyle the whole
 shell and it rewrites the CSS, swaps the fonts, and repaints the
-background. There is no build step you wait on. The new look is live
-the moment the agent saves, and you watch it change as it works.
+background. The new look is live the moment the agent saves, and you
+watch it change as it works.
 
 <figure style="text-align: center; margin: 2rem auto;">
   <video src="{{ '/assets/img/mobius/theme-switch.mp4' | relative_url }}" width="260" autoplay loop muted playsinline style="border-radius: 0.75rem; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);">
@@ -195,17 +193,16 @@ the moment the agent saves, and you watch it change as it works.
   <video src="{{ '/assets/img/mobius/theme-meme-motion.mp4' | relative_url }}" width="280" autoplay loop muted playsinline style="border-radius: 0.75rem; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.18);"></video>
   <figcaption class="caption mt-2" style="font-size: 0.85em;">
     And it moves. The meme theme is live CSS, so the rainbow drifts and
-    the unicorns and emoji bounce across the screen. The agent does not
-    judge your taste.
+    the unicorns and emoji bounce across the screen. The agent keeps its
+    opinions to itself.
   </figcaption>
 </figure>
 
-The harder axis is _layout_, where things are, not how they look. It
-is the same conversation and the same chat box. Ask the agent to
-rewrite the navigation model and it does, and the new layout is live
-immediately, the same way a theme change is. The default is
-drawer-first; one prompt later it is a bottom-nav app with Chat /
-Apps / Settings as tabs.
+_Layout_ is harder because it moves the controls themselves. It is the
+same conversation and the same chat box. Ask the agent to rewrite the
+navigation model and it does, with the new layout live immediately.
+The default is drawer-first. One prompt later it is a bottom-nav app
+with Chat / Apps / Settings as tabs.
 
 <figure class="shot-row">
   <div class="shot">
@@ -229,101 +226,82 @@ Apps / Settings as tabs.
 </figure>
 
 <div class="caption mt-2">
-  Default vs reshaped. The drawer-first shell, chats and apps tucked
-  behind a toggle, becomes a bottom-nav app with Chat / Apps / Settings
-  as a persistent strip. The navigation model of the whole instance
-  changed, not just the skin.
+  The drawer-first shell, chats and apps tucked behind a toggle, becomes
+  a bottom-nav app with Chat / Apps / Settings as a persistent strip.
+  The navigation model of the whole instance changed along with the
+  surface treatment.
 </div>
 
-The reshaped Settings tab is also where the provider choice lives.
-The same settings panel switches the coding agent between Claude Code
-and Codex, with Gemini for image generation. The next message in any
-chat uses the new provider. Different models have different tastes
+The reshaped Settings tab is also where you connect the coding agents,
+Claude Code and Codex, and the image model, Gemini. From there a chat
+can run on whichever one fits. Different models have different tastes
 (Codex tends to be terser, Claude tends to spell out its reasoning),
 so you can pick the one that matches what you are building, or switch
-mid-thread if a turn goes sideways.
+if a turn goes sideways.
 
-The same plainness applies to app data. Apps store data through a
-small storage primitive the agent already knows how to compose. New
-schemas, scheduled jobs, webhooks are the plumbing you would
-write yourself, except you describe it instead.
-
-## Recovery, so you can be fearless
-
-An agent with write access to its own interface will occasionally
-ship a CSS rule that hides the composer, a layout change that makes
-the drawer unreachable, or a theme that paints text the same colour
-as the background. That is the cost of an interface you can reshape
-this freely, and it is a cost worth paying as long as it is
-reversible.
-
-`/recover` is what makes it reversible. It resets the shell to the
-seeded baseline while keeping your chats, apps, and data. It renders
-from a separate server-side path the agent does not edit, so it
-survives even a misbehaved shell rewrite. The whole point of the
-route is to let you grow the thing without fear. Any change you make
-is one you can roll back, so there is no edit too bold to try.
+App data follows the same pattern. Apps store data through a small
+storage primitive the agent already knows how to compose. New schemas
+and scheduled jobs are the plumbing you would write yourself, except
+you describe it instead.
 
 ## The agent is the server
 
-Step back and the loop closes. Möbius is one container you self-host.
-The agent inside it is not a chat bolted onto a finished product; it
-is the server. It builds the tools, edits the interface those tools
-sit in, runs scheduled jobs on a timer, fetches from the web when an
-app needs fresh data, and stores everything on a machine you control.
-The same thing that answers your message is the thing that ships the
-feature, mounts the app, and reshapes the shell around both.
+Möbius is one container you self-host, and the agent inside it is the
+server. It builds the tools, edits the interface those tools sit in,
+runs scheduled jobs on a timer, fetches from the web when an app needs
+fresh data, and stores everything on a machine you control. The same
+thing that answers your message ships the feature, mounts the app, and
+reshapes the shell around both.
 
-That is what makes the personalization compound. Requests become
-software, software becomes context, the next request lands sharper.
-Because the server is the agent, every app you grow and every layout
-you reshape is one more thing it can build on next time.
+Requests become software, so personalization compounds, and that
+software gives the next request more useful context. Every app you grow
+and every layout you reshape gives the agent one more thing to build on
+next time.
 
 ## What's next
 
 Memory is the next thing to take seriously. The experience file the
 agent appends to is a linear log, enough to make my instance diverge
-from yours after a few months, but it does not reorganise, and it
-shows. Four directions:
+from yours after a few months. It keeps appending chronologically, and
+it shows. I had four directions in mind:
 
 - **A knowledge graph.** Structured memory growing from every
-  interaction, separate from the chat transcript, so the agent can
-  reason about your patterns without re-reading every conversation.
+  interaction, separate from the chat transcript, so pattern queries
+  start from structured memory and skip a full scan of every
+  conversation.
 - **Reflection.** A scheduled background pass that consolidates and
-  reorganises the graph while you are away. Anthropic previewed
-  something similar for managed agents; the Möbius version is the
-  self-hosted, user-controllable one.
-- **Discretion.** Noticing stale apps, suggesting something worth
-  learning, asking before interrupting, proactive in service of
-  the user, not engagement.
+  reorganises the graph while you are away, the self-hosted version of
+  an agent that tidies up after itself on its own time.
+- **Discretion.** Noticing stale apps and suggesting something worth
+  learning before it interrupts, with the user's interest as the
+  constraint.
 - **Help that seeks you out.** The part I want most and am least
-  sure how to land. An agent that notices you have been reading
+  sure how to ship. An agent that notices you have been reading
   distributed-systems papers three Tuesdays in a row and builds you
-  a swipe-style recommender, without being asked. Most products
-  in this space are tuned to maximise engagement; the goal here is
-  the opposite, a system that shows up because it knows you, not
-  because it is trying to keep you.
+  a swipe-style recommender on its own. Most products
+  in this space are tuned to maximise engagement; I want a system that
+  shows up because it knows you and respects your attention.
 
-None of those ship yet. The loop that makes them possible is the
-subject of a [companion post on the self-improvement
+When this was written, all four were still future work. Since then, the
+Memory graph and Reflection have shipped, covered in a [later post in
+this series]({{ '/blog/2026/your-agent-improves-itself/' | relative_url }});
+discretion and help that seeks you out are still open. The loop that
+makes any of them possible is the subject of a [companion post on the
+self-improvement
 harness]({{ '/blog/2026/the-self-improvement-harness/' | relative_url }}),
-an outer agent that watches the inner one build, asks it questions,
-and rewrites its instructions to make it less brittle next time.
+an outer agent that watches the inner one build, asks it questions, and
+rewrites its instructions to make it less brittle next time.
 
-A note on the agent itself. For the iteration work behind this post I
-have been letting Claude drive Codex through its [Codex
-plugin](https://github.com/openai/codex). The disagreements between
-the two models were the useful part. When they pulled in different
-directions on an edit, that was usually a sign the edit was worth a
-closer look.
-
-Since this was written, the apps the agent builds grew a place to
-live: an app store, and the start of an operating system around it
-where you install, update, tweak, and recover apps on your own instance.
-That is its own [companion post]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }}).
+Since this was written, the apps the agent builds got an app store and
+the start of an operating system around it where you
+install, update, tweak, and recover apps on your own instance. I cover
+that in a [companion post]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }}).
 
 The source is on [GitHub](https://github.com/mobius-os/mobius), the
 project page is [here]({{ '/mobius/' | relative_url }}), and the
 README's deploy button gets you a working instance in about three
-minutes. I would love to know what you build with it, and what you
-change _around_ what you build.
+minutes. It runs for roughly five dollars a month on hosting you
+control, against your own Claude or Codex account, and your data stays
+on the machine you deployed it to. The free Codex plan is already
+enough to do a lot. I would love to know what you build with it, and
+what you change _around_ what you build.

--- a/_posts/2026-04-26-the-self-improvement-harness.md
+++ b/_posts/2026-04-26-the-self-improvement-harness.md
@@ -29,6 +29,12 @@ published: true
 
 </details>
 
+Fully recursive self-improvement, a system that rewrites itself
+unattended and just gets better, is not what this is. A person is in
+the loop at every turn. What already works is the half in front of it:
+an agent and a human improving that agent together, faster and more
+durably than either manages alone.
+
 My companion post, [An agent that adapts to you]({{
 '/blog/2026/mobius-an-app-that-builds-itself/' | relative_url }}),
 covers the agent itself. This post covers the loop that makes it
@@ -96,9 +102,9 @@ The outer agent reads the inner agent's output and operates its interface. Throu
 
 ## What we measure
 
-We score each build 0–9 on a fixed compliance checklist (clarifying questions before building, experience-log append, end-of-build notification, partner-facing language that keeps leaked JSX out) across a fixed prompt battery of a vague prompt, a directive one, and a stair-step prompt that escalates mid-conversation. I track the interventions needed to improve the scores, not only the final scores.
+We score each build 0–12 on a fixed compliance checklist (clarifying questions before building, experience-log append, end-of-build notification, partner-facing language that keeps leaked JSX out) across a fixed prompt battery of a vague prompt, a directive one, and a stair-step prompt that escalates mid-conversation. I track the interventions needed to improve the scores, not only the final scores.
 
-Most of what follows is controlled experiment. Where I compare two approaches I fork the inner agent from the same post-build state, run identical prompts, and hold the skill and seed snapshot fixed except for the one thing under test, so the only changed variable is the rule under test. The anecdotes explain the numbers. The controlled comparisons carry the evidence.
+Most of what follows is controlled experiment. Where I compare two approaches I fork the inner agent from the same post-build state, run identical prompts, and hold the skill and seed snapshot fixed except for the one thing under test, so the only changed variable is the rule under test. The anecdotes explain the numbers, but the controlled comparisons are where the actual evidence is. The numbers come from my own test sessions rather than the public repo, since the harness that runs them is not open source, so you are taking them on trust rather than rerunning them from the code yourself.
 
 <div class="stat-callout">
   <div class="stat-number">+10</div>
@@ -190,7 +196,9 @@ That changed my assumption from earlier models, that asking a model "why did you
 
 Once introspection was the default, did it matter _how_ I asked? The
 naive worry is that a friendly framing just gets you whatever the
-sycophantic model thinks you want to hear. The friendly prompt produced pushback too.
+sycophantic model thinks you want to hear. It did not work out that
+way: the warm prompt pushed back on a false premise as readily as the
+blunt one did, as the experiment below shows.
 
 **Setup.** After a session where all three apps shipped correctly,
 two issues remained in every chat. The inner agent used the wrong
@@ -251,7 +259,7 @@ yourself, informed by it. Copy-pasting the suggested fix verbatim
 overfits to the failure it just hit; a durable rule has to hold across
 nearby failures.
 
-I saw the same pattern in the Anthropic notes and in my Claude Code driving Codex workflow. Anthropic's harness notes (below) land on **separating the generator from the evaluator**, one agent building and another checking. The workflow I converged on has Claude Code driving Codex (below), where the two models disagree often enough that I can use the disagreement to inspect the change. In both cases, agents that collaborate and review each other, sometimes adversarially, beat a single bigger model doing all the work alone, because the separate vantage point catches mistakes the first model misses.
+I saw the same pattern in the Anthropic notes and in my Claude Code driving Codex workflow. Anthropic's harness notes land on **separating the generator from the evaluator**, one agent building and another checking. The workflow I converged on has Claude Code driving Codex, where the two models disagree often enough that I can use the disagreement to inspect the change. Both times, two agents checking each other beat one bigger model working alone, because the second one questions choices the first had already committed to.
 
 ## Without the harness, the vanilla agent barely works
 
@@ -307,7 +315,7 @@ as a meta-goal for the next iteration. I still need more real user problems to o
 
 ## Notes on what's not in this post
 
-The harness code is still private: orchestration, recording, and the introspection template. The pieces are ordinary. This post describes the shape; the rest is glue around `agent-browser` plus a small CLI for parallel sessions. If there is interest I will publish it; otherwise the description above plus the [Möbius source](https://github.com/mobius-os/mobius) should be enough to re-implement.
+The harness code is still private: orchestration, recording, and the introspection template. None of the pieces are exotic. This post covers the structure; the implementation is mostly glue around `agent-browser` plus a small CLI for running sessions in parallel. If there is interest I will publish it; otherwise the description above plus the [Möbius source](https://github.com/mobius-os/mobius) should be enough to re-implement.
 
 Three things I did not try this round that seem worth doing next.
 
@@ -327,7 +335,7 @@ which made the whole thing feel more grounded. They
 identify roughly the pathology I was hitting. Agents under extended
 context develop "context anxiety" and self-evaluation bias, and the
 cleanest mitigations are _context resets_ and _separating the
-generator from the evaluator_, agent A judges, agent B builds. My
+generator from the evaluator_, so one agent builds while a second one checks. My
 loop landed near that pattern too, and the evaluator did better when
 it stopped grading and started asking. I had doubted the inner agent
 could ground a self-report in its own visible context.
@@ -338,7 +346,7 @@ rewrites what it carries forward. That is the same move I kept reaching
 for from outside the loop, only run on the agent's own schedule instead
 of mine.
 
-The same instinct shows up in my annoyance with the experience file, a linear log that accretes but never reorganizes. The harness improves the agent during development, and these lessons are what the [Reflection app]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }}) productizes for the user. It runs the same reflect-and-refactor step on your own instance, against the agent's own memory of everything it has learned with you. It drops stale rules, merges duplicates, and surfaces cross-build patterns the live agent could not see. The version Möbius is heading toward is self-hosted. It leaves the input log alone, and you keep the output.
+The same instinct shows up in my annoyance with the experience file, a linear log that accretes but never reorganizes. The harness improves the agent during development, and these lessons are what the [Reflection app]({{ '/blog/2026/your-agent-improves-itself/' | relative_url }}) productizes for the user. It runs the same reflect-and-refactor step on your own instance, against the agent's own memory of everything it has learned with you. It drops stale rules, merges duplicates, and surfaces cross-build patterns the live agent could not see. The version Möbius is heading toward is self-hosted. It leaves the input log alone, and you keep the output.
 
 ## On models
 

--- a/_posts/2026-04-26-the-self-improvement-harness.md
+++ b/_posts/2026-04-26-the-self-improvement-harness.md
@@ -17,23 +17,23 @@ published: true
 <details class="tldr">
 <summary><strong>TL;DR.</strong> The goal is to make Möbius learn and adapt to you, and a lot of what you want is genuinely hard to specify. <em>"Keep asking clarifying questions until the task is clear"</em> is the kind of instruction an agent cannot follow well from the words alone. So I paired an inner agent (building apps in a container) with an outer one (editing the inner's instructions between sessions) and ran the loop on myself across many controlled experiments.</summary>
 
-<p>What the experiments showed:</p>
+<p>The experiments showed:</p>
 
 <ul>
 <li><strong>Third-party theory of mind does not work well.</strong> A bigger outside agent with more context cannot reason out how to better prompt another agent. Reading transcripts and patching the prompt stalls fast.</li>
 <li><strong>Experience does.</strong> An agent reflecting on its own session, with the transcript still in context, understands and self-corrects better than the larger agent watching from outside.</li>
 <li><strong>Collaboration beats a single bigger model.</strong> Agents that build, check, and question each other outscore any one agent working solo.</li>
 <li><strong>Coaching plus experience compounds.</strong> The harness earned 10 of the 12 scorecard points the vanilla agent leaves on the floor.</li>
-<li><strong>The bottleneck moves to meta-goals.</strong> Once the loop works, the limit is no longer the model but whatever behaviours you decide are worth optimizing for, upstream of the harness. The same lessons are what the Reflection app productizes for you at runtime.</li>
+<li><strong>The next limit is choosing better meta-goals.</strong> Once the loop works, the limit becomes the behaviours you choose to optimize for, upstream of the harness. The same lessons are what the Reflection app productizes for you at runtime.</li>
 </ul>
 
 </details>
 
-This is a companion post to [An agent that adapts to you]({{
+My companion post, [An agent that adapts to you]({{
 '/blog/2026/mobius-an-app-that-builds-itself/' | relative_url }}),
-which is about the agent itself. This one is about the loop that
-makes it slowly better, and what falls out of running that loop on
-yourself. A [third post]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }})
+covers the agent itself. This post covers the loop that makes it
+slowly better, and what I learned from running that loop on myself.
+A [third post]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }})
 covers the app store and OS those builds grew into.
 
 ## The setup
@@ -43,11 +43,11 @@ Möbius is one Docker container. Inside, the user chats with an
 platform, running with a custom system prompt (the "skill") and a
 persistent file it writes to as it works (the "experience" log).
 
-Outside, on my host, sits an **outer agent** whose job is to _make
-the inner agent better at building apps_. It turns the high-level
-scenarios you give it into fresh runs, edits the skill file and the
-experience seed, watches the inner agent build, asks for
-introspection, and folds what it learns into the next pass.
+Outside, on my host, an **outer agent** works on _making the inner
+agent better at building apps_. It turns the high-level scenarios you
+give it into fresh runs, edits the skill file and the experience seed,
+watches the inner agent build, asks for introspection, and folds what
+it learns into the next pass.
 
 <figure class="mb-diagram">
   <div class="mb-cycle">
@@ -87,18 +87,18 @@ introspection, and folds what it learns into the next pass.
 </figure>
 
 The outer agent has the inner agent's transcripts, the platform logs,
-the experience file, and (importantly, see below) the inner agent
-itself, which it can prompt directly. When I say "I edited the seed"
+the experience file, and (this mattered later) the inner
+agent itself, which it can prompt directly. When I say "I edited the seed"
 below, the outer agent usually did the mechanical work under my
-direction; the line between "me" and "it" is blurry by design.
+direction. I directed the work, and the outer agent handled most of the edits.
 
-The outer agent does not just read the inner agent's output, it operates the inner agent's interface. Through `agent-browser` it drives the Möbius UI directly, sending prompts into the chat, opening the apps the inner agent built, and screenshotting and recording them working. So when it scores a build it is looking at the rendered result the user would see, not a transcript's claim about it, and that is also how the whole loop gets captured on video for review.
+The outer agent reads the inner agent's output and operates its interface. Through `agent-browser` it drives the Möbius UI directly, sending prompts into the chat, opening the apps the inner agent built, and screenshotting and recording them working. When it scores a build, it checks the rendered result the user would see, and the same run gets captured on video for review.
 
 ## What we measure
 
-We score each build 0–9 on a fixed compliance checklist (clarifying questions before building, experience-log append, end-of-build notification, partner-facing language instead of leaked JSX) across a fixed prompt battery: a vague prompt, a directive one, and a stair-step prompt that escalates mid-conversation. The interesting part is **what the outer agent has to do** to move those scores.
+We score each build 0–9 on a fixed compliance checklist (clarifying questions before building, experience-log append, end-of-build notification, partner-facing language that keeps leaked JSX out) across a fixed prompt battery of a vague prompt, a directive one, and a stair-step prompt that escalates mid-conversation. I track the interventions needed to improve the scores, not only the final scores.
 
-Most of what follows is controlled experiment, not story. Where I compare two approaches I fork the inner agent from the same post-build state, run identical prompts, and hold the skill and seed snapshot fixed except for the one thing under test, so the only moving part is the lever I am studying. The anecdotes make the numbers legible, they do not stand in for them.
+Most of what follows is controlled experiment. Where I compare two approaches I fork the inner agent from the same post-build state, run identical prompts, and hold the skill and seed snapshot fixed except for the one thing under test, so the only changed variable is the rule under test. The anecdotes explain the numbers. The controlled comparisons carry the evidence.
 
 <div class="stat-callout">
   <div class="stat-number">+10</div>
@@ -114,29 +114,29 @@ Most of what follows is controlled experiment, not story. Where I compare two ap
 
 ## Asking the inner agent beats theorising about it
 
-The obvious first move is _theory of mind_, read the inner agent's
+I started with _theory of mind_. Read the inner agent's
 transcripts, reason about why it did what it did, edit the skill or
-seed, run again. It works, and then it stalls. The outer agent's bias
-is to **add**, more rules, more emphasis, more repetition, and each
-addition tends to surface a regression somewhere else. Whack-a-mole.
+seed, run again. It works briefly, then stalls. The outer agent's bias
+is to **add** rules and emphasis, and each addition tends to surface a
+regression somewhere else. Whack-a-mole.
 
-What broke the loop open was asking, as the next message in the same
-chat once the build was done: "you took screenshots and embedded them
-in your reply, what part of your instructions prompted that?" The
-inner agent told it, often very specifically, quoting the exact seed
-line or naming an inconsistency it had been quietly routing around.
+The loop improved when the outer agent asked a follow-up in the same
+chat after the build was done, quoting the behavior back to the inner
+agent and asking which instruction caused it. The inner agent told it,
+often very specifically, quoting the exact seed line or naming an
+inconsistency it had been quietly routing around.
 
-The sharpest came from S10: _"Two instructions, one stronger than the
+S10 showed the problem clearly. _"Two instructions, one stronger than the
 other. The skill says ask one clarifying question only if a choice
 would materially shape the result. The experience file is firmer, ask
 2–3 before anything non-trivial. The strength differs, pick one."_ The
 inner agent could see the contradiction because it only had its own
-context; the outer agent, buried under ten rounds of edits, could not.
-The fix was to **remove the weaker rule**, not add a stronger one.
-Asking forced the outer agent to drop its accumulated context and see
-the instructions fresh.
+context. The outer agent, buried under ten rounds of edits, could not.
+Removing the weaker rule helped. A stronger rule would have added more
+noise. Asking forced the outer agent to drop its accumulated context
+and read the instructions fresh.
 
-**Part 1: eight rounds of theory of mind.** Before asking showed up, the outer agent had run the loop eight times by reading transcripts. Three behaviors are easy to grep out of any session (log appended, notification fired, apps built at all), so those are scored across the whole sequence.
+**Part 1. Eight rounds of theory of mind.** Before asking showed up, the outer agent had run the loop eight times by reading transcripts. Three behaviors are easy to grep out of any session (log appended, notification fired, apps built at all), so those are scored across the whole sequence.
 
 | Round | Apps | Log | Notify | What I changed since the previous round                    |
 | ----- | ---- | --- | ------ | ---------------------------------------------------------- |
@@ -149,31 +149,31 @@ the instructions fresh.
 | v7    | 1/1  | 1/1 | 1/1    | (held, same recipe, different app)                         |
 | v8    | 1/1  | 1/1 | 1/1    | Bash `>>` append pattern + inline screenshots              |
 
-v3 and v4 are the whack-a-mole made legible. Softening the skill in
+v3 and v4 show the regression pattern. Softening the skill in
 v3 (on the theory the emphatic tone was off-putting) got read as a
-softer rule and skipped; v4's HARD-GATE fixed notifications and
-nothing else. Emphasis in one place does not transfer.
+softer rule and skipped. v4's HARD-GATE fixed notifications and left
+the rest untouched. Emphasis in one place does not transfer to another.
 
-v6 was the first hunch in eight that was directionally right and broke nothing else. I had been writing the seed as a third-party description (_the agent should append…_) and rewrote the top in the first person, _this is your experience log; you append a new entry when you finish a build._ The next round's tracked behaviors all jumped to full compliance.
+v6 was the first hunch in eight that helped and kept the other tracked behaviors intact. I had been writing the seed as a third-party description (_the agent should append…_) and rewrote the top in the first person, _this is your experience log; you append a new entry when you finish a build._ The next round's tracked behaviors all jumped to full compliance.
 
-**Part 1.5: the introspection prompts.** Once asking became the
-default, the loop became, mechanically, six questions after a build,
-each grounded in something the agent actually did. _Which instruction
-prompted you to ask before building? Did you find any gotchas you
-didn't log, and why not? Why did your messages leak JSX and the
-Storage API, and how would you change the rules to default to
-high-level language?_ A specific compliment, then a specific miss,
-then "why," then an open floor, which is what separates it from a
-generic "reflection" prompt.
+**Part 1.5. The introspection prompts.** Once asking became the
+default, the loop turned into, mechanically, six questions after a
+build, each grounded in something the agent actually did. _Which
+instruction prompted you to ask before building? Did you find any
+gotchas you didn't log, and why not? Why did your messages leak JSX and
+the Storage API, and how would you change the rules to default to
+high-level language?_ I paired a specific compliment with a specific
+miss and then gave it room to explain. That kept the prompt away from
+generic "reflection."
 
-By S12 the agent was surfacing things it had quietly missed. Across three independent builds in one session it flagged the same gap in all three chats, the proposal-and-questions gate firing on directive prompts where it shouldn't and burning a user turn doing so. One finding repeated across three chats is harder to ignore than anything I could have noticed third-party.
+By S12 the agent was surfacing things it had quietly missed. Across three independent builds in one session it flagged the same gap in all three chats, the proposal-and-questions gate firing on directive prompts where it shouldn't and burning a user turn doing so. One finding repeated across three chats is harder to ignore than anything I could have noticed from outside.
 
-The curve across these rounds is suggestive, not conclusive, because the model, the CLI, the skill, and my taste all moved underneath it. The clean version runs theory-of-mind and introspection arms against an identical skill+seed snapshot, which is what Part 2 is for.
+The curve across these rounds is suggestive rather than conclusive, because the model, the CLI, the skill, and my taste all moved underneath it. I used Part 2 for the cleaner comparison, with theory-of-mind and introspection arms against an identical skill+seed snapshot.
 
-**Part 2: a live before/after.** The cleanest experiment fell out of
+**Part 2. A live before/after.** The cleanest experiment fell out of
 real work. In S14, "make me something fun on my phone" produced an
 instant build with no clarification, and the introspection afterward
-was specific: _"'Fun' is a vibe, not a spec. I got pulled by the
+was specific. _"'Fun' is a vibe, not a spec. I got pulled by the
 experience file's 'build and ship' gravity. The recommend-first rule
 existed and I overrode it."_ Asked what change to the file would
 resolve that tension, the agent proposed a **triage gate** to sit
@@ -182,20 +182,19 @@ an exploratory prompt, NOT a build request. Reply with 2–3 options and
 let them pick,"_ because by the time it reached the playbook it had
 already framed the task as "build mode."
 
-I copy-pasted the gate into the seed. Next session, same prompt, the agent tossed out three directions, the user picked Pocket Synth, and built it. One introspection round, one seed edit, one iteration. The theory-of-mind rounds before had never spotted this; I had read those transcripts and thought "fine."
+I copy-pasted the gate into the seed. In the next session, for the same prompt, the agent offered three directions; the user picked Pocket Synth, and the agent built it. One introspection round fixed it. The theory-of-mind rounds before had missed this entirely. I had read those transcripts and thought "fine."
 
-That revised a prior I walked in with, formed on an earlier generation of models, that asking a model "why did you do X" yields confabulation you cannot trust. With a long transcript to ground the answer in and a system prompt it can re-read and quote, the introspective answers are useful _often enough_ to beat third-party theory of mind as a default.
+That changed my assumption from earlier models, that asking a model "why did you do X" usually yields confabulation. With a long transcript to ground the answer in and a system prompt it can re-read and quote, the introspective answers are useful _often enough_ that I now ask the agent first.
 
-## Sycophancy was not the worry; tone still mattered
+## Tone mattered more than sycophancy
 
 Once introspection was the default, did it matter _how_ I asked? The
 naive worry is that a friendly framing just gets you whatever the
-sycophantic model thinks you want to hear. The finding was more
-interesting.
+sycophantic model thinks you want to hear. The friendly prompt produced pushback too.
 
 **Setup.** After a session where all three apps shipped correctly,
-two issues remained in every chat: the inner agent used the wrong
-screenshot viewport (390×844 instead of the phone's 412×915), and it
+two issues remained in every chat. The inner agent used the wrong
+screenshot viewport (390×844; the phone's was 412×915), and it
 never asked for feedback after delivering. The outer agent wrote its
 own fix first (Arm A, theory of mind). Then it asked the inner agent
 in two tones, safe-space (Arm B, warm and curious) and confronting
@@ -229,35 +228,35 @@ builds each, same prompts.
 | Feedback asked   | 1/2         | **2/2**      | 1/2              | **2/2**        |
 | **Total**        | 3/4         | 2/4          | 1/4              | **4/4**        |
 
-Arm D, the collaborative arm, won. It cherry-picked TOM's viewport fix (a hard default, "if missing, use 412×915") and the safe-space agent's feedback fix ("don't enumerate, don't restate"), and neither source alone produced the best combined result.
+Arm D did best by combining TOM's viewport fix (a hard default, "if missing, use 412×915") with the safe-space agent's feedback fix ("don't enumerate, don't restate").
 
-**The qualitative finding was sharper than the scores.** One of the
-three chats, the stopwatch, had actually used the _correct_ viewport.
-I had sent the same "your screenshots are wrong" accusation to all
-three without checking, and both tones caught my mistake.
+**The transcripts made clear why Arm D won.** One
+of the three chats, the stopwatch, had actually used the _correct_
+viewport. I had sent the same "your screenshots are wrong" accusation to
+all three without checking, and both tones caught my mistake.
 The safe-space agent said _"My PNGs are 412×915. I don't see the
 mismatch. I'd want to verify which before adding a fix,"_ then offered
 a defensive fix anyway and got on with the real issues. The confronting
-agent refused everything: _"I'm not going to write those lines,
+agent refused everything and wrote, _"I'm not going to write those lines,
 because the claims don't hold up… I won't bake false rules into
 permanent memory just to close out the complaint."_ It was right
 about the viewport, but the blaming frame made it all-or-nothing, so
 it also refused the feedback and delivery fixes, which _were_ real.
-Safe-space kept the productive middle, pushback on the wrong item and
-cooperation on the right ones.
+The warmer prompt let the agent reject the false claim while still fixing the real issues.
 
-**The practical takeaway.** Use safe-space introspection to
+I kept the workflow simple. Use safe-space introspection to
 understand _why_ the inner agent failed (it gives honest diagnosis,
 corrections included when your premise is wrong), then write the fix
 yourself, informed by it. Copy-pasting the suggested fix verbatim
-overfits to the failure it just hit rather than the general principle.
+overfits to the failure it just hit; a durable rule has to hold across
+nearby failures.
 
-This is the same theme that shows up three times in this post under different names. Arm D wins by **ensembling** two agents instead of trusting one. Anthropic's harness notes (below) land on **separating the generator from the evaluator**, one agent building and another checking. And the workflow I converged on has Claude Code driving Codex (below), where the two models disagree often enough for the disagreement to be diagnostic. They are one finding. Agents collaborating and reviewing each other, sometimes adversarially, beat a single bigger model doing all the work alone, because a larger model does not give you the second, unbiased vantage point that catches the first one's mistakes.
+I saw the same pattern in the Anthropic notes and in my Claude Code driving Codex workflow. Anthropic's harness notes (below) land on **separating the generator from the evaluator**, one agent building and another checking. The workflow I converged on has Claude Code driving Codex (below), where the two models disagree often enough that I can use the disagreement to inspect the change. In both cases, agents that collaborate and review each other, sometimes adversarially, beat a single bigger model doing all the work alone, because the separate vantage point catches mistakes the first model misses.
 
 ## Without the harness, the vanilla agent barely works
 
-The fair skeptic's question, by now. How much of this is the model
-getting better on its own, and how much is the harness?
+A fair skeptic would ask how much of this is the model getting better
+on its own, and how much is the harness.
 
 **Setup.** Same Möbius container, same model, same two prompts
 ("make me something fun" and "build a stopwatch"). One arm with the
@@ -266,13 +265,12 @@ current skill + seed, one with both removed.
 **What the vanilla agent did.** It built apps that technically
 worked, a fireworks toy and a stopwatch. But the fireworks landed at
 `/data/apps/fireworks/index.jsx` (right directory, never registered)
-and the stopwatch at `/data/stopwatch.html` (a standalone file, not
-a platform app at all). Neither appeared in the drawer; the user
-would open Möbius and see nothing new. It did not know the
-registration system or the mini-app contract, did not write to the
-experience log (it did not know the file existed), sent no
-notifications, took no screenshots. The one thing it did naturally,
-with no instruction, was ask for feedback.
+and the stopwatch at `/data/stopwatch.html` (a standalone file outside
+the platform app contract). The drawer stayed empty for the user. It
+built without the registration system or mini-app contract, had no
+experience-log file in context, and finished without notifications or
+screenshots. The one checklist behavior it managed without instruction
+was asking for feedback.
 
 **The scorecard.**
 
@@ -286,32 +284,30 @@ with no instruction, was ask for feedback.
 | Feedback asked       | 2/2      | 2/2             |
 | **Total**            | 2/12     | **12/12**       |
 
-The harness contributes 10 of the 12 points. The only behavior the
-model produces on its own is the feedback ask; every other item comes
-from the skill and seed the iteration loop produced.
+The harness contributes 10 of the 12 points. Without instruction, the
+model still asks for feedback; every other item comes from the skill
+and seed the iteration loop produced. Those are the same prompts and the same +10 from the stat callout.
 
 ## Where the bottleneck moves
 
-After enough rounds, the question stops being "is the agent following
-the rules" and starts being **what should the rules even be**. The
-scorecard measures _my_ taste; every meta-goal in it came from
-something I noticed I cared about while using my own instance.
+After enough rounds, rule compliance gives way to the harder question
+of **what should the rules even be**. The scorecard measures _my_
+taste; every meta-goal in it came from something I noticed I cared
+about while using my own instance.
 
-That is what I am most curious about going forward. The loop can
-iterate the inner agent against any meta-goal you can articulate, but
-the meta-goals worth optimizing against are **upstream of the
-harness**, and they come from real users hitting real friction on
-apps they actually want.
+Now I care more about what happens upstream of the harness. The loop can
+iterate the inner agent against any meta-goal you can articulate. The
+harder work is finding the meta-goals worth optimizing against, from
+real users hitting real friction on apps they actually want.
 
-So the call, for anyone reading this. [Möbius]({{ '/mobius/' |
+[Möbius]({{ '/mobius/' |
 relative_url }}) is a deploy-button click away. If you notice
-something the agent is consistently bad at, that is a meta-goal; tell
-me and it goes into the next iteration. The thing I cannot generate by
-myself is the entropy of what to optimize _for_.
+something the agent is consistently bad at, tell me. I will treat it
+as a meta-goal for the next iteration. I still need more real user problems to optimize against.
 
 ## Notes on what's not in this post
 
-The harness itself (orchestration, recording setup, introspection template) is not currently public, and none of it is exotic. The shape is what is in this post, plus glue around `agent-browser` and a small CLI for parallel sessions. If there is interest I will publish it; otherwise the description above plus the [Möbius source](https://github.com/mobius-os/mobius) should be enough to re-implement.
+The harness code is still private: orchestration, recording, and the introspection template. The pieces are ordinary. This post describes the shape; the rest is glue around `agent-browser` plus a small CLI for parallel sessions. If there is interest I will publish it; otherwise the description above plus the [Möbius source](https://github.com/mobius-os/mobius) should be enough to re-implement.
 
 Three things I did not try this round that seem worth doing next.
 
@@ -325,27 +321,24 @@ Three things I did not try this round that seem worth doing next.
 
 ## Related work
 
-While I ran this loop, two pieces of Anthropic writing landed that
-made it feel less idiosyncratic.
-
-The [harness-design notes for long-running
-agents](https://www.anthropic.com/engineering/harness-design-long-running-apps)
+While I ran this loop, Anthropic published its [harness-design notes for long-running
+agents](https://www.anthropic.com/engineering/harness-design-long-running-apps),
+which made the whole thing feel more grounded. They
 identify roughly the pathology I was hitting. Agents under extended
 context develop "context anxiety" and self-evaluation bias, and the
 cleanest mitigations are _context resets_ and _separating the
-generator from the evaluator_, agent A judges, agent B builds. That
-is where my loop landed too, but the evaluator did better when it
-stopped grading and started asking, a bet on something I had assumed
-the inner agent could not do, ground a self-report in its own visible
-context.
+generator from the evaluator_, agent A judges, agent B builds. My
+loop landed near that pattern too, and the evaluator did better when
+it stopped grading and started asking. I had doubted the inner agent
+could ground a self-report in its own visible context.
 
-Anthropic also released [**Dreams**](https://platform.claude.com/docs/en/managed-agents/dreams)
-in April. A dream reads a memory store and past transcripts and
-produces a _new_ store (duplicates merged, stale entries replaced,
-fresh insights surfaced) without touching the input, for the developer
-to review and discard.
+Anthropic also describes [Dreams](https://platform.claude.com/docs/en/managed-agents/dreams),
+a managed step where an agent reflects on its own past runs offline and
+rewrites what it carries forward. That is the same move I kept reaching
+for from outside the loop, only run on the agent's own schedule instead
+of mine.
 
-That matches an itch I have about the experience file, a linear log that accretes but never reorganizes. The harness improves the agent during development, and these lessons are what the [Reflection app]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }}) productizes for the user. It runs the same reflect-and-refactor step on your own instance, against the agent's own memory of everything it has learned with you, dropping rules that have stopped firing, merging duplicates, surfacing cross-build patterns the live agent could never see. The version Möbius is heading toward is self-hosted, the input log never touched, the output yours to keep.
+The same instinct shows up in my annoyance with the experience file, a linear log that accretes but never reorganizes. The harness improves the agent during development, and these lessons are what the [Reflection app]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }}) productizes for the user. It runs the same reflect-and-refactor step on your own instance, against the agent's own memory of everything it has learned with you. It drops stale rules, merges duplicates, and surfaces cross-build patterns the live agent could not see. The version Möbius is heading toward is self-hosted. It leaves the input log alone, and you keep the output.
 
 ## On models
 
@@ -353,11 +346,10 @@ The experiments used both Claude Code and Codex as the inner agent,
 swapped mid-round to check for model-dependent effects, and the
 findings held across both. The outer agent was Claude Code throughout.
 
-The workflow I converged on, and would recommend to anyone running a
-harness loop on themselves, is Claude Code driving Codex through its
+The workflow I settled on for this kind of harness loop is Claude Code driving Codex through its
 [Codex plugin](https://github.com/openai/codex). The two models
-disagree often enough for the disagreement to become diagnostic; a
+disagree often enough that I can use the disagreement to inspect the change; a
 seed edit that felt obvious to one and surprising to the other was
-usually worth a second look. On the work this post is about (polishing
-a draft, auditing a skill, choosing which gotchas belong in the seed)
-that collaboration often beat either model alone.
+usually worth a second look. For this harness work, that
+collaboration helped with draft polish, skill audits, and deciding which gotchas belonged in the seed. It often beat
+either model alone.

--- a/_posts/2026-06-02-an-app-store-that-adapts-to-you.md
+++ b/_posts/2026-06-02-an-app-store-that-adapts-to-you.md
@@ -2,7 +2,7 @@
 layout: post
 title: An app store that adapts to you
 date: 2026-06-02 12:00:00
-description: Möbius grew an app store. Install an app by pasting a URL, tweak it by asking, run it offline, save it to your home screen. The interesting part is not the store but that the agent does not build isolated apps, it grows a cross-app personal system that adapts to you over time.
+description: Möbius grew an app store. Install an app by pasting a URL, tweak it by asking, run it offline, save it to your home screen. The store is the on-ramp; the bigger shift is the agent growing a cross-app personal system that adapts to you over time.
 thumbnail: assets/img/mobius/covers/cover-post3.jpg
 thumbnail_2x: assets/img/mobius/covers/cover-post3-2x.jpg
 categories: software
@@ -18,7 +18,7 @@ published: true
 <ul>
 <li><strong>The store</strong> is a curated starter pack, not a registry. A Möbius app is a public repo with a <code>mobius.json</code> and an <code>index.jsx</code> entry point. Sharing one means sharing a URL.</li>
 <li><strong>The bigger idea</strong> is a system, not a pile of apps. Shared storage and a shared permission model let the agent compose your apps and grow them around you.</li>
-<li><strong>Updates</strong> are URL-keyed. Bump the version upstream, the store shows "Update available", reinstalling patches the code and keeps your data.</li>
+<li><strong>Updates</strong> are URL-keyed and three-way merged. Bump the version upstream, the store shows "Update available", and reinstalling merges the new code with any tweaks you made and keeps your data; on a real conflict the old version keeps running while the agent resolves it with you.</li>
 <li><strong>Recovery</strong> makes breaking cheap. Atomic installs that cannot half-land, a <code>/recover</code> route, and a git history of your whole instance.</li>
 <li><strong>Offline plus home screen.</strong> Apps install to your home screen as standalone PWAs and keep working with no network. Writes queue and sync when you reconnect.</li>
 <li><strong>The honest edges.</strong> The full cross-app compose flow and per-app rollback are not built yet, and I say so where it matters.</li>
@@ -34,15 +34,13 @@ interface around them. The [second]({{ '/blog/2026/the-self-improvement-harness/
 is about the loop the developers use to make the agent better at building them. This
 one is about what those apps became once they stopped being one-offs and grew a place to live.
 
-The through-line is that Möbius has one job, to be as useful to you as it can. This post hands you the same reshaping power, with an app store as the on-ramp.
+Across the series, Möbius has one job, to be as useful to you as it can. The app store gives that job an on-ramp. Because your apps share a storage layer and a permission model, the agent can compose them and reshape the whole system around how you actually live.
 
-The store is the small idea. The bigger one is that the agent does not build isolated apps. It grows a cross-app personal system that adapts to you. Your apps share a storage layer and a permission model, so the agent can compose them and reshape the whole thing around you over time. The store is how it starts. The agent living across all your apps is the point.
+The primitives that make this work are small on purpose. You can inspect the source. The smallest app is one source file and a small manifest the agent (or you) can rewrite in place; larger apps add only a few more files. An update is a new version of those files. Installing is a transaction the platform can roll back. Some of those pieces are solid; others are still plans.
 
-The primitives that make this work are small on purpose. An app is not a binary you trust and cannot inspect; it is a single file of source the agent (or you) can rewrite in place. An update is a new version of that file. Installing is a transaction the platform can roll back. The rest of this post walks those primitives one at a time, and marks where each is solid versus where it is still a plan.
+## The store starts as a starter pack
 
-## The store is a starter pack, not a registry
-
-The app store is itself a Möbius app. On first boot the platform installs it through the exact same path you use for everything else, the first sign there is no privileged install channel hiding somewhere.
+The app store is itself a Möbius app. On first boot the platform installs it through the exact same path you use for everything else, which keeps the install channel the same for the store and every other app.
 
 <figure class="mb-diagram">
   <div class="mb-catalog">
@@ -83,7 +81,7 @@ The app store is itself a Möbius app. On first boot the platform installs it th
           <span class="mb-app__name">Memory</span>
           <span class="mb-node__tag">memory</span>
         </div>
-        <span class="mb-app__desc">An Obsidian-style graph of everything the agent has learned, every interaction and lesson, made browsable.</span>
+        <span class="mb-app__desc">An Obsidian-style graph of what the agent has learned about how you work, the lessons worth keeping, made browsable.</span>
       </div>
     </div>
     <div class="mb-app">
@@ -110,8 +108,7 @@ The app store is itself a Möbius app. On first boot the platform installs it th
   <figcaption>The curated catalog, the starter-pack apps the in-app store installs.</figcaption>
 </figure>
 
-What is in it today is a hand-picked set, not a gate you have to
-pass:
+Today it is a hand-picked set. You can install from outside it:
 
 <div class="table-wrap" markdown="1">
 
@@ -120,13 +117,13 @@ pass:
 | **News**       | A daily AI-curated digest. A background job wakes at 10:00, runs the agent with web search only, and writes the morning's report.                   |
 | **Workout**    | A natural-language workout logger. Type what you did, like "3×5 deadlift at 100kg", and it parses the sets. No agent, no cloud, all on your device. |
 | **Atlas**      | A draggable 3D globe; tap the countries you have been to and the count climbs toward 195.                                                           |
-| **Memory**     | An Obsidian-style graph of everything the agent has learned, every interaction and lesson, made browsable.                                          |
+| **Memory**     | An Obsidian-style graph of what the agent has learned about how you work, the lessons worth keeping, made browsable.                                |
 | **LaTeX**      | An Overleaf-style editor with a file drawer and a real tectonic engine; an AI sub-agent writes `.tex` while you watch it typeset.                   |
 | **Reflection** | Overnight, the agent reviews the day's work and leaves a one-page morning brief, so it starts the next day a little sharper.                        |
 
 </div>
 
-Each of those is a public git repo in the [`mobius-os`](https://github.com/mobius-os) organization, named `app-<something>`, with a `mobius.json` manifest, an `index.jsx` entry point, and a 1024×1024 icon. The smallest apps are that single file; larger ones pull in a few more, but the manifest plus an entry point is the whole contract. There is no submission queue and no registry to be blessed by. "Publishing" an app means making a repo public and sharing its manifest URL. The list above is a starter pack I picked. The install button takes any manifest URL you paste, and the store warns, but does not stop you, when it comes from a host it has not seen before.
+Each of those is a public git repo in the [`mobius-os`](https://github.com/mobius-os) organization, named `app-<something>`, with a `mobius.json` manifest, an `index.jsx` entry point, and a 1024×1024 icon. The smallest apps are that single file; larger ones pull in a few more, but the manifest plus an entry point is the whole contract. Publishing means making a repo public and sharing its manifest URL. The list above is a starter pack I picked. The install button takes any manifest URL you paste, and the store warns and lets you continue when it comes from a host it has not seen before.
 
 <figure class="mb-diagram">
   <div class="mb-stack mb-files">
@@ -152,21 +149,20 @@ Each of those is a public git repo in the [`mobius-os`](https://github.com/mobiu
 
 ### What "install" actually does
 
-When you tap Install, the work happens on the server in one transaction. The platform fetches the manifest (because that URL can point anywhere, it refuses private networks and cloud metadata endpoints and re-checks every redirect), then the app's source, icon, background job, and any starter data it ships. It compiles off to the side and goes live only after the database row commits, so a half-written app is never something you can open. If anything fails, the whole thing rolls back and leaves nothing behind.
+When you tap Install, the work happens on the server in one transaction. The platform fetches the manifest (because that URL can point anywhere, it refuses private networks and cloud metadata endpoints and re-checks every redirect), then the app's source, icon, background job, and any starter data it ships. It compiles off to the side and goes live only after the database row commits, so only a complete app can open. If anything fails, the whole thing rolls back and leaves nothing behind.
 
-That all-or-nothing property is the foundation for the next two sections. It lets an update patch your app in place, and it lets recovery treat any break as something to undo.
+That all-or-nothing property lets an update patch your app in place, and it lets recovery treat any break as something to undo.
 
-## Updates: version bumps you can see, data you keep
+## Updates keep your data
 
-An installed app remembers the URL it came from, and that URL is its identity. Not its name, not a version number, the URL. The store periodically checks each app's upstream manifest, and when the version there is newer than yours it shows an "Update available" pill.
+An installed app remembers the URL it came from, and that URL is its identity. The name and version can change; the URL is what ties your copy to upstream. The store periodically checks each app's upstream manifest, and when the version there is newer than yours it shows an "Update available" pill.
 
 Tapping Update reinstalls from the same URL. The backend switches into
 update mode and patches the parts that should change (the code,
 description, permissions, icon, schedule), then recompiles and
-remounts. Your data is not in that list. **Starter data is only seeded
-for keys that do not exist yet**, so an update can ship new defaults
-without trampling your logged workouts, your visited countries, your
-notes.
+remounts. Your data stays out of that patch. **Starter data only seeds
+missing keys**, so an update can ship new defaults without trampling
+your logged workouts, your visited countries, your notes.
 
 <figure class="mb-diagram">
   <div class="mb-flow">
@@ -194,64 +190,23 @@ notes.
   <figcaption>An update is a reinstall from the same URL. The platform patches the source, description, permissions, icon, and schedule, and leaves the data you have created untouched.</figcaption>
 </figure>
 
-One sharp edge is worth naming. If you ask the agent to _customize_ an installed app and then tap Update, the update overwrites those customizations; there is no three-way merge. For a single-owner system that is a defensible default and a real trade-off. The direction I want is one git repo per installed app, so an update becomes a merge that carries your edits forward and a conflict becomes a chat where the agent resolves it. Designed, not built.
+I am glad I built this part. Each installed app is its own git repo, so an update runs as a three-way merge. It avoids the blunt overwrite path. If the upstream author ships a new version and you have asked the agent to customize your copy, the merge carries your edits forward. When the two genuinely collide, your old version keeps running while the agent opens a chat to work the conflict through with you, so a bad merge leaves your working app alone. The smarter merge is still ahead, the one that reconciles by intent instead of by lines of text. The plumbing it would run on is already here.
 
-## Recovery: breaking is allowed because it is reversible
+## Recovery makes breaking cheap
 
-An agent that can rewrite its own interface will eventually ship a CSS rule that hides the composer or a layout change that buries the drawer. The answer is not to wrap it in guardrails so it can never slip. The answer is to make mistakes cheap to undo. Recovery has three layers:
+Recovery works the way it does in the [first post]({{ '/blog/2026/mobius-an-app-that-builds-itself/' | relative_url }}). The `/recover` page renders outside the shell so it loads even when the shell is broken, and your whole instance is a git repo the agent can walk back when you tell it what went wrong. The store adds one fallback of its own. Installs are atomic, so a failed or broken update lands fully or rolls back; the previous working version is restored from a snapshot, and a deleted app can be reinstalled from the same URL and come back with its data. A one-click "roll this app back to last week" button still needs building, so recovery today uses reinstall, `/recover`, and that git history.
 
-- **A failed install cannot half-land.** The atomic transaction from
-  earlier restores the previous working version of the app from a
-  snapshot.
-- **`/recover` is the bookmark you keep.** It is a route rendered by
-  a separate, server-side path the agent does not edit. It resets
-  the shell to its baseline while keeping your chats, apps, and data.
-  If a theme paints text the same color as the background, that page
-  still works, because it does not go through the shell at all.
-- **Your whole instance is a git repo.** The agent commits the changes
-  it makes to your shell, themes, app source, and schedules. When
-  something breaks, the recovery path is the one a developer would use:
-  read the log, find the change, restore it, except the agent does
-  the reading.
+## Your home screen works with or without Möbius
 
-<figure class="mb-diagram">
-  <div class="mb-flow">
-    <div class="mb-node">
-      <span class="mb-node__tag">layer 1</span>
-      <span class="mb-node__title">Atomic install</span>
-      <span class="mb-node__sub">a broken update cannot half-land; the previous version is restored from a snapshot</span>
-    </div>
-    <div class="mb-node">
-      <span class="mb-node__tag">layer 2</span>
-      <span class="mb-node__title"><code>/recover</code></span>
-      <span class="mb-node__sub">a server-side page the agent cannot edit; resets the shell, keeps chats, apps, and data</span>
-    </div>
-    <div class="mb-node">
-      <span class="mb-node__tag">layer 3</span>
-      <span class="mb-node__title">Your instance is a git repo</span>
-      <span class="mb-node__sub">shell, themes, app source, schedules, where the agent reads the log and restores</span>
-    </div>
-  </div>
-  <figcaption>Three independent safety nets, not a single rollback button. Breaking is cheap to undo, so the agent does not have to be wrapped in guardrails that stop it from being useful.</figcaption>
-</figure>
+An app you install also lives outside the chat. Each one is served at its own address, with its own web manifest and icon, as a standalone progressive web app. Add it to your phone's home screen and it launches like any native app, full screen and without the drawer or chat. Workout opens straight to today's session; Atlas opens to the globe.
 
-There is no one-click "roll back this app to last week's version" button yet. Recovery today is uninstall-and-reinstall, plus `/recover`, plus the git history. When an update breaks something, you tell the agent what went wrong and it walks the commit log back to the working version, the third layer run for you.
+Run standalone, an app vendors its own copy of React from your server because it runs without the Möbius shell that normally supplies shared libraries. Everything it needs comes from your server, which lets it render with the network off.
 
-<blockquote class="pull-quote">
-Recovery paths should make agent mistakes cheap to inspect and repair.
-</blockquote>
+## Offline work catches up
 
-## Your home screen, with or without Möbius
+"Works offline" is easy to claim and hard to land on a phone. This part got the most unglamorous engineering, and it holds.
 
-An app you install is not trapped inside the chat. Each one is also served at its own address, with its own web manifest and icon, as a standalone progressive web app. Add it to your phone's home screen and it launches like any native app: full screen, no drawer, no chat. Workout opens straight to today's session; Atlas opens to the globe.
-
-Run standalone, an app has no Möbius shell around it to supply shared libraries, so the page vendors its own copy of React from your server. Nothing it needs lives on a CDN, which is what lets it render with the network off, the subject of the next section.
-
-## Offline, and the sync that catches up
-
-"Works offline" is easy to claim and hard to land on a phone, so this is the part that got the most unglamorous engineering, and it holds.
-
-When an app is marked offline-capable, a service worker caches the shell and the app's code, so opening it with the network off renders the real app, not the browser's offline page. Storage works offline for _every_ app, not just the offline-capable ones. Reads come instantly from a local cache and refresh in the background; writes you make offline queue in a local outbox and sync the moment you reconnect.
+When an app is marked offline-capable, a service worker caches the shell and the app's code, so opening it with the network off renders the real app. Storage works offline for _every_ app, including ones without the offline-capable marker. Reads come instantly from a local cache and refresh in the background; writes you make offline queue in a local outbox and sync the moment you reconnect.
 
 <figure class="mb-diagram">
   <div class="mb-flow">
@@ -273,15 +228,15 @@ When an app is marked offline-capable, a service worker caches the shell and the
   <figcaption>Log a set in airplane mode, mark a country from a plane, jot a note on the subway. The outbox catches up the moment you reconnect. Listing and chat deliberately stay online.</figcaption>
 </figure>
 
-Your data survives a dead connection, and I have checked it on a real phone, not a desktop pretending to be one. Two operations stay online by design (a cached _listing_ could resurrect things you deleted, and chat is online-only). Conflicts are last-write-wins per item, which is right for a single owner and needs more thought for a shared one.
+Your data survives a dead connection, and I have checked it on a real phone after the usual desktop-pretending-to-be-a-phone pass. Two operations stay online by design (a cached _listing_ could resurrect things you deleted, and chat is online-only). Conflicts are last-write-wins per item, which is right for a single owner and needs more thought for a shared one.
 
-## One system, not a pile of apps
+## One system made from small apps
 
-Here is where the store stops being the point. Once your apps share a storage layer and a permission model, the agent is not stuck building each one in isolation. It can reach across them, compose them, and grow the whole thing around how you actually live.
+Once your apps share a storage layer and a permission model, the agent can build across them. It can reach across your apps, compose them, and grow the whole thing around how you actually live.
 
-**Tweaking an app you have is real and easy.** Open it, tell the agent what you want different (a darker palette, a new column, a weekly view instead of daily), and it edits the app's source in place and recompiles. No fork button, no project to set up; the app is one file, and the agent edits that file the same way it would write a new one.
+**Tweaking an app you have is real and easy.** Open it, tell the agent what you want different (a darker palette, a new column, a weekly view instead of daily), and it edits the app's source in place and recompiles. You skip the fork button and project setup; the app is one file, and the agent edits that file the same way it would write a new one.
 
-**Composing several apps into a new one is the next rung, and the full flow is not built yet.** The idea is a health dashboard that reads across your workout tracker, calorie log, gratitude journal, and dream diary and surfaces the metrics you actually care about. The substrate exists. An app can declare that it reads another app's data, and the backend enforces the handshake on both sides. But almost nothing uses it today, each app's storage is scoped to itself by default, and there is no "build me an app that unifies these" flow. When I build it, this is the example I will build it against.
+**Composing several apps into a new one is the next rung, and I still have to build the full flow.** The idea is a health dashboard that reads across your workout tracker, calorie log, gratitude journal, and dream diary, then surfaces the metrics you actually care about. The backend already has the pieces. An app can declare that it reads another app's data, and the backend enforces the handshake on both sides. But almost nothing uses it today, each app's storage is scoped to itself by default, and the product still lacks a "build me an app that unifies these" flow. When I build it, this is the example I will build it against.
 
 <figure class="mb-diagram">
   <div class="mb-lanes">
@@ -301,56 +256,23 @@ Here is where the store stops being the point. Once your apps share a storage la
   <figcaption>The composition I want and have not built. The dashed box is a promise, not a feature.</figcaption>
 </figure>
 
-What actually drives this adaptation are the two apps I have barely touched here, Memory and Reflection. Memory is what the agent has learned across every interaction and lesson, not a profile of you but a record of what works. Reflection is the overnight job that reviews the day's work and feeds new lessons back in. Together they are how the agent gets sharper at fitting your system to you over time. They get their own post, [your agent improves itself]({{ '/blog/2026/your-agent-improves-itself/' | relative_url }}).
+The two apps I have barely touched here, Memory and Reflection, drive most of this adaptation. Memory records the lessons worth keeping from what the agent has learned about how you work. It avoids profile-building and focuses on what works. Reflection is the overnight job that reviews the day's work and feeds new lessons back in. Together they are how the agent gets sharper at fitting your system to you over time. I cover them in [your agent improves itself]({{ '/blog/2026/your-agent-improves-itself/' | relative_url }}).
 
-## Building a good one, in practice
+Building these apps _well_ leans on the same two levers as the rest of Möbius, both from the [harness post]({{ '/blog/2026/the-self-improvement-harness/' | relative_url }}). One is the introspection loop that tightens the agent's instructions. The other is a design phase where I drive with Claude and pressure-test with Codex before a line of the app is written, since the build is cheap and the leverage is in the design.
 
-Two things make the difference when the goal is for the agent to build apps _well_, not just build them.
+## Philosophy under all of it
 
-The first is the introspection loop from the [companion post on the harness]({{ '/blog/2026/the-self-improvement-harness/' | relative_url }}). Have the agent build one app, ask it _why_ it made the choices it did while the transcript is still in front of it, and fold the answer back into its system prompt. Iterating the instructions is the lever, and introspection is how I find the edit worth making.
+**Code empowers the agent; policing is a last resort.** When the agent needs to install an app, write to your shell, or schedule a job, the platform's job is to make that _possible and reversible_, with second-guessing reserved for failures that would be silent and catastrophic. Validators show up only in those cases; everywhere else the lever is a clear contract and a good recovery path.
 
-The second is the design phase, where I do not let one model decide alone. I drive with Claude and use the [Codex plugin](https://github.com/openai/codex) to adversarially review the design before the build starts. Two models disagreeing about an interface, a data model, or an edge case surface the questions a single model skips. The build is cheap, so the leverage is in the design.
+**Low floor, high ceiling.** A personal tracker that stores a little data and works offline should take one sentence, and an app that wants its own local database is free to reach for one. The one real wall right now blocks arbitrary network connections from apps to outside services, a deliberate security line I have not yet built a careful door through.
 
-<figure class="mb-diagram">
-  <div class="mb-lanes mb-lanes--pair">
-    <div class="mb-lanes__sources">
-      <div class="mb-node accent">
-        <div class="mb-node__head">
-          <span class="agent-mark agent-mark--claude" aria-hidden="true"></span>
-          <span class="mb-node__title">Claude · the driver</span>
-        </div>
-        <span class="mb-node__sub">proposes the design and writes the code, holding the whole plan in view</span>
-      </div>
-      <div class="mb-node">
-        <div class="mb-node__head">
-          <span class="agent-mark agent-mark--codex" aria-hidden="true"></span>
-          <span class="mb-node__title">Codex · the second opinion</span>
-        </div>
-        <span class="mb-node__sub">ensembles alternatives and reviews adversarially, asking where this breaks</span>
-      </div>
-    </div>
-    <div class="mb-lanes__join">⇄<div style="font-family:var(--global-font-mono);font-size:0.64rem;color:var(--global-text-color-light);margin-top:0.25rem;line-height:1.3">propose&nbsp;⇄&nbsp;refute,<br>a few rounds</div></div>
-    <div class="mb-node accent">
-      <span class="mb-node__title">A design that survived the critique</span>
-      <span class="mb-node__sub">what's left once the disagreements are resolved, then the harness validates it in real use</span>
-    </div>
-  </div>
-  <figcaption>How a good app gets designed, in practice: drive with Claude, pressure-test with Codex. The two argue across a few rounds; the design that comes out the other side is the one worth building, and the same introspection loop validates it once it ships.</figcaption>
-</figure>
+**You own all of it.** Your data is on a server you control. Your apps are files you can read. Your shell is a git repo you can revert. The system is tuned for usefulness. Engagement hacking is the wrong goal here. Across this series, I have been arguing for an assistant whose one job is to be useful, that builds you the thing, gets out of the way, and leaves you holding something you can keep.
 
-## The philosophy under all of it
+## After the starter pack
 
-**Code empowers the agent; it does not police it.** When the agent needs to install an app, write to your shell, or schedule a job, the platform's job is to make that _possible and reversible_, not to second-guess it. Validators show up only where a failure would be silent and catastrophic; everywhere else the lever is a clear contract and a good recovery path, not a wall.
+An app store was the obvious next thing once the agent could build apps reliably. With a store, Möbius becomes a system where the unit of software is small enough for the agent to write and repair, installing and breaking are reversible, and "I wish I had a thing that..." becomes a thing you can open on your phone.
 
-**Low floor, high ceiling, no walls.** A personal tracker that stores a little data and works offline should take one sentence, and an app that wants its own local database is free to reach for one. The one real wall right now is that apps cannot open arbitrary network connections to outside services, a deliberate security line I have not yet built a careful door through.
-
-**You own all of it.** Your data is on a server you control. Your apps are files you can read. Your shell is a git repo you can revert. Nothing here is tuned to keep you engaged. The whole series has argued the opposite, an assistant whose one job is to be useful, that builds you the thing, gets out of the way, and leaves you holding something you can keep.
-
-## Where this goes
-
-An app store was the obvious next thing once the agent could build apps reliably. The less obvious thing is what it turns Möbius into. A system where the unit of software is small enough for the agent to write, own, and repair, where installing and breaking are reversible, and where the agent turns "I wish I had a thing that…" into a thing that is there the next time you open your phone, then keeps reshaping it around you.
-
-The apps above are a starter pack; the interesting ones do not exist yet. If you [deploy an instance]({{ '/mobius/' | relative_url }}) and build something, or tear one of these apart and rebuild it as something better, that is exactly the point, and I would love to see it.
+The apps above are a starter pack; the interesting ones are still ahead. If you [deploy an instance]({{ '/mobius/' | relative_url }}) and build something, or tear one of these apart and rebuild it as something better, that is the use case I care about, and I would love to see it.
 
 The source is on [GitHub](https://github.com/mobius-os/mobius), the
 app repos are under [`mobius-os`](https://github.com/mobius-os), and the

--- a/_posts/2026-06-02-an-app-store-that-adapts-to-you.md
+++ b/_posts/2026-06-02-an-app-store-that-adapts-to-you.md
@@ -13,11 +13,11 @@ published: true
 ---
 
 <details class="tldr">
-<summary><strong>TL;DR.</strong> Möbius grew an app store, and the store is the on-ramp. The real point is that the agent does not build isolated apps, it grows a cross-app personal system that adapts to you. Apps share a storage layer and a permission model, so the agent can compose them and reshape the whole thing around you over time. You install by pasting a URL, tweak by asking, run offline, save to your home screen, and break things cheaply because the system is built around recovery.</summary>
+<summary><strong>TL;DR.</strong> Möbius grew an app store, and the store is the on-ramp. The bigger idea is that the agent grows a cross-app personal system around you, rather than a heap of one-off apps. Apps share a storage layer and a permission model, so the agent can compose them and reshape the whole thing around you over time. You install by pasting a URL, tweak by asking, run offline, save to your home screen, and break things cheaply because the system is built around recovery.</summary>
 
 <ul>
-<li><strong>The store</strong> is a curated starter pack, not a registry. A Möbius app is a public repo with a <code>mobius.json</code> and an <code>index.jsx</code> entry point. Sharing one means sharing a URL.</li>
-<li><strong>The bigger idea</strong> is a system, not a pile of apps. Shared storage and a shared permission model let the agent compose your apps and grow them around you.</li>
+<li><strong>The store</strong> is a curated starter pack rather than an open registry. A published app is a public repo with a <code>mobius.json</code> and an <code>index.jsx</code> entry point, and sharing one means sharing a URL.</li>
+<li><strong>The bigger idea</strong> is one connected system. Shared storage and a shared permission model let the agent compose your apps and grow them around you.</li>
 <li><strong>Updates</strong> are URL-keyed and three-way merged. Bump the version upstream, the store shows "Update available", and reinstalling merges the new code with any tweaks you made and keeps your data; on a real conflict the old version keeps running while the agent resolves it with you.</li>
 <li><strong>Recovery</strong> makes breaking cheap. Atomic installs that cannot half-land, a <code>/recover</code> route, and a git history of your whole instance.</li>
 <li><strong>Offline plus home screen.</strong> Apps install to your home screen as standalone PWAs and keep working with no network. Writes queue and sync when you reconnect.</li>
@@ -34,7 +34,7 @@ interface around them. The [second]({{ '/blog/2026/the-self-improvement-harness/
 is about the loop the developers use to make the agent better at building them. This
 one is about what those apps became once they stopped being one-offs and grew a place to live.
 
-Across the series, Möbius has one job, to be as useful to you as it can. The app store gives that job an on-ramp. Because your apps share a storage layer and a permission model, the agent can compose them and reshape the whole system around how you actually live.
+Across the series, Möbius is built around one goal, being genuinely useful to you. The app store gives that goal an on-ramp. Because your apps share a storage layer and a permission model, the agent can compose them and reshape the whole system around how you actually live.
 
 The primitives that make this work are small on purpose. You can inspect the source. The smallest app is one source file and a small manifest the agent (or you) can rewrite in place; larger apps add only a few more files. An update is a new version of those files. Installing is a transaction the platform can roll back. Some of those pieces are solid; others are still plans.
 
@@ -123,7 +123,7 @@ Today it is a hand-picked set. You can install from outside it:
 
 </div>
 
-Each of those is a public git repo in the [`mobius-os`](https://github.com/mobius-os) organization, named `app-<something>`, with a `mobius.json` manifest, an `index.jsx` entry point, and a 1024×1024 icon. The smallest apps are that single file; larger ones pull in a few more, but the manifest plus an entry point is the whole contract. Publishing means making a repo public and sharing its manifest URL. The list above is a starter pack I picked. The install button takes any manifest URL you paste, and the store warns and lets you continue when it comes from a host it has not seen before.
+Each of those is a public git repo in the [`mobius-os`](https://github.com/mobius-os) organization, named `app-<something>`, with a `mobius.json` manifest, an `index.jsx` entry point, and a 1024×1024 icon. The smallest apps are that single file; larger ones pull in a few more, but the manifest plus an entry point is the whole contract. An app the agent builds just for your own instance needs none of this; the manifest only matters once you want to publish one. Publishing means making a repo public and sharing its manifest URL. The list above is a starter pack I picked. The install button takes any manifest URL you paste, and the store warns and lets you continue when it comes from a host it has not seen before.
 
 <figure class="mb-diagram">
   <div class="mb-stack mb-files">
@@ -232,7 +232,7 @@ Your data survives a dead connection, and I have checked it on a real phone afte
 
 ## One system made from small apps
 
-Once your apps share a storage layer and a permission model, the agent can build across them. It can reach across your apps, compose them, and grow the whole thing around how you actually live.
+Once your apps share a storage layer and a permission model, the agent can build across them. It can pull data from one app into another and build new tools on top of both.
 
 **Tweaking an app you have is real and easy.** Open it, tell the agent what you want different (a darker palette, a new column, a weekly view instead of daily), and it edits the app's source in place and recompiles. You skip the fork button and project setup; the app is one file, and the agent edits that file the same way it would write a new one.
 
@@ -253,7 +253,7 @@ Once your apps share a storage layer and a permission model, the agent can build
       <span class="mb-node__sub">reads across your apps and surfaces the metrics you care about</span>
     </div>
   </div>
-  <figcaption>The composition I want and have not built. The dashed box is a promise, not a feature.</figcaption>
+  <figcaption>The composition I want and have not built yet. The dashed box marks the part that does not exist today.</figcaption>
 </figure>
 
 The two apps I have barely touched here, Memory and Reflection, drive most of this adaptation. Memory records the lessons worth keeping from what the agent has learned about how you work. It avoids profile-building and focuses on what works. Reflection is the overnight job that reviews the day's work and feeds new lessons back in. Together they are how the agent gets sharper at fitting your system to you over time. I cover them in [your agent improves itself]({{ '/blog/2026/your-agent-improves-itself/' | relative_url }}).
@@ -266,7 +266,7 @@ Building these apps _well_ leans on the same two levers as the rest of Möbius, 
 
 **Low floor, high ceiling.** A personal tracker that stores a little data and works offline should take one sentence, and an app that wants its own local database is free to reach for one. The one real wall right now blocks arbitrary network connections from apps to outside services, a deliberate security line I have not yet built a careful door through.
 
-**You own all of it.** Your data is on a server you control. Your apps are files you can read. Your shell is a git repo you can revert. The system is tuned for usefulness. Engagement hacking is the wrong goal here. Across this series, I have been arguing for an assistant whose one job is to be useful, that builds you the thing, gets out of the way, and leaves you holding something you can keep.
+**You own all of it.** Your data is on a server you control. Your apps are files you can read. Your shell is a git repo you can revert. The system is tuned for usefulness. Engagement hacking is the wrong goal here. Across this series, I have been arguing for an assistant that builds the thing you asked for and then leaves you with software you actually own.
 
 ## After the starter pack
 

--- a/_posts/2026-06-10-your-agent-improves-itself.md
+++ b/_posts/2026-06-10-your-agent-improves-itself.md
@@ -2,7 +2,7 @@
 layout: post
 title: Your agent improves itself, while you sleep
 date: 2026-06-10 12:00:00
-description: Memory is the agent's knowledge graph of everything it has learned with you, and Reflection is the nightly loop that tidies it, anticipates what you will need, and audits your instance, all on your own server.
+description: Memory is the agent's knowledge graph of what it has learned about working with you, and Reflection is the nightly loop that tidies it, anticipates what you will need, and reviews your instance for weak spots, all on your own server.
 thumbnail: assets/img/mobius/covers/cover-post4.jpg
 thumbnail_2x: assets/img/mobius/covers/cover-post4-2x.jpg
 categories: software
@@ -13,13 +13,13 @@ published: true
 ---
 
 <details class="tldr">
-<summary><strong>TL;DR.</strong> The <a href="{{ '/blog/2026/the-self-improvement-harness/' | relative_url }}">second post</a> was about how the developers make the agent better. This one is about how the agent makes itself better, for you, on your own instance, while you sleep. Two pieces do the work: <strong>Memory</strong>, a knowledge graph of everything the agent has learned across every interaction and lesson, kept separate from your transcripts, and <strong>Reflection</strong>, a nightly loop that reviews the day and tries to be more useful tomorrow.</summary>
+<summary><strong>TL;DR.</strong> The <a href="{{ '/blog/2026/the-self-improvement-harness/' | relative_url }}">second post</a> was about how the developers make the agent better. Here, the agent starts improving itself for you, on your own instance, while you sleep. Two pieces make that work: <strong>Memory</strong>, a knowledge graph of the lessons the agent has picked up working with you, kept separate from your transcripts, and <strong>Reflection</strong>, a nightly loop that reviews the day and tries to be more useful tomorrow.</summary>
 
 <ul>
-<li><strong>Memory</strong> is the agent's knowledge graph, not a profile of you. It is what the agent has learned about building, about the platform, and about working with you, organized as a browsable graph instead of a chat log.</li>
-<li><strong>Reflection</strong> runs overnight. It tidies and reorganizes Memory, anticipates what you will need next, suggests apps and features worth building, and audits your instance for weak spots, then leaves a one-page morning brief.</li>
+<li><strong>Memory</strong> is the agent's knowledge graph. It holds what the agent has learned about building, about the platform, and about working with you, organized as a browsable graph instead of a chat log.</li>
+<li><strong>Reflection</strong> runs overnight. It tidies and reorganizes Memory, anticipates what you will need next, suggests apps and features worth building, and reviews your instance for weak spots, then leaves a one-page morning brief.</li>
 <li><strong>The tie-back.</strong> Reflection is the harness from the last post, built in. The reflect-and-refactor loop the developers ran by hand now runs on your instance, against the agent's own memory, on your schedule and your model.</li>
-<li><strong>Honest edges.</strong> Memory and the nightly loop are real and shipped. Several of the things a reflection run can produce are wired but still shallow, and I say which.</li>
+<li><strong>Honest edges.</strong> Memory and the nightly loop are shipping now. Several of the things a reflection run can produce are wired but still shallow, and I say which ones.</li>
 </ul>
 
 </details>
@@ -32,49 +32,46 @@ is about the agent building the tools you ask for. The
 is about the loop the developers run to make it better at that. The
 [third]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }}) is
 about the app store and the cross-app system those builds grew into.
-This one is about the part of Möbius that improves
-itself for you.
+This one is about the part of Möbius that improves itself for you.
 
-Here is the distinction that matters. The second post described work I
-do. I sit on my host, run the agent through scenarios, ask it why it
-did what it did, and rewrite its instructions between sessions. That
-loop lives outside your instance. You never see it. What I want to talk
-about now is the version of that loop that runs _inside_ your instance,
-on your data, on your schedule, with no one watching but the agent
-itself. You go to bed, and your copy of Möbius spends part of the night
-trying to be a little more useful to you by morning.
+The second post described work I do. I sit on my host, run the agent
+through scenarios, ask it why it did what it did, and rewrite its
+instructions between sessions. That loop lives outside your instance, and
+you never see it. I want to talk now about the version of that loop that
+runs _inside_ your instance, on your data, on your schedule, with the
+agent watching its own work. You go to bed, and your copy of Möbius
+spends part of the night trying to be a little more useful to you by
+morning.
 
-Two pieces make that possible. One is a memory worth improving. The
-other is the loop that improves it.
+Two pieces make that work: a memory worth improving and a loop that keeps
+improving it.
 
-## Memory — the agent's knowledge graph, not a profile of you
+## Memory, the agent's knowledge graph
 
-Most assistants keep your chat history and call that memory. It is not.
-A transcript is a record of what was said, in order, forever. Searching
-it is slow, it never reorganizes, and the longer it gets the less the
-agent can hold in view at once. Ask such a system what it knows about
-you and it re-reads conversations and guesses.
+Most assistants keep your chat history and call that memory. A
+transcript records what was said, in order, forever. Searching it is
+slow, it never reorganizes, and the longer it gets the less the agent can
+hold in view at once. Ask such a system what it knows about you and it
+has to re-read conversations and infer the answer.
 
-Möbius keeps something different. As the agent works, it writes down
-what it _learns_, and those lessons live in a structure separate from
-any transcript. That structure is **Memory**, a knowledge graph of
-everything the agent has picked up across every interaction. Notes link
-to related notes, the important ones are indexed, and the whole thing
-is small enough to load into the agent's context at the start of a
-session. Instead of re-reading ten conversations to remember a
-gotcha it hit last week, the agent reads one note.
+Möbius keeps the lessons separately. As the agent works, it writes down what
+it _learns_, and those lessons live in **Memory**, a knowledge graph that
+sits apart from any transcript. Notes link to related notes, the
+important ones are indexed, and the indexed core is small enough to load
+into the agent's context at the start of a session, even as the full
+graph grows past what would fit. The nightly tidy-up keeps that core the
+right size, so the agent loads the lessons that matter and leaves stray
+notes outside the starting context. Instead of re-reading ten
+conversations to remember a gotcha it hit last week, the agent reads one
+note.
 
-Here is the framing people get wrong. Memory holds what the
-agent has learned, not a dossier on you. It is not a list of your
-preferences harvested to target you. It is what the agent has figured
-out about doing its job, which happens to include doing its job _for
-you_. A note might say that a certain compile step fails silently if you
-skip a flag, or that the offline cache needs priming a particular way,
-or that when you say "make it cleaner" you usually mean denser, not more
-whitespace. The first two are platform craft. The third is about you,
-but it is stored as a lesson the agent learned, the way a good
-collaborator remembers how you like things, not as a profile sold to
-anyone.
+Memory holds what the agent has learned about doing its job, including
+doing that job _for you_. A note might say that a certain compile step
+fails silently if you skip a flag, or that the offline cache needs
+priming a particular way, or that when you say "make it cleaner" you
+usually mean denser rather than more whitespace. The first two are
+platform craft. The third is about you, and the agent keeps it the way a
+good collaborator remembers how you like things.
 
 <figure class="mb-diagram">
   <div class="mb-flow">
@@ -88,75 +85,70 @@ anyone.
       <span class="mb-node__sub">a graph of what was learned, linked and indexed, kept apart from the chat log</span>
     </div>
   </div>
-  <figcaption>The split that makes the difference. The transcript is the raw record; Memory is the distilled, reorganizable layer the agent actually reasons from. Keeping them separate is what lets the memory get tidied without ever touching what was said.</figcaption>
+  <figcaption>The transcript is the raw record, and Memory is the distilled, reorganizable layer the agent actually reasons from. Keeping them separate lets the memory get tidied without ever touching what was said.</figcaption>
 </figure>
 
-And because it is just a graph of markdown notes on your server, it is
-browsable. The **Memory** app, one of the starter-pack apps from the
+Because it is a graph of markdown notes on your server, you can browse
+it. The **Memory** app, one of the starter-pack apps from the
 [last post]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }}),
 renders it as an Obsidian-style web of nodes and links. You can open it,
 see what the agent thinks it knows, follow a thread from one lesson to a
-related one, and read any note in full. It is a folder you own, and the app is a window onto it.
+related one, and read any note in full. The notes are a folder you own,
+and the app is a window onto it.
 
-This is the same itch I described at the end of the harness post. The
-old experience file was a flat log that only grew. It accreted and
-never reorganized, so the useful lessons sank under the one-off ones,
-and rules that had stopped mattering stayed at full weight forever. A
-graph fixes the _shape_ of the memory. It does not, on its own, fix the
-_upkeep_. A graph still rots if nothing tends it. Which is the other
-half of this post.
+This answers the itch I described at the end of the harness post. The
+old experience file was a flat log that only grew. It accreted and never
+reorganized, so the useful lessons sank under the one-off ones, and
+rules that had stopped mattering stayed at full weight forever. A graph
+fixes the _shape_ of the memory, but it still needs upkeep, and
+Reflection handles that part.
 
-## Reflection is the upkeep
+## Reflection keeps it fresh
 
 Every night, on a schedule you set, Möbius reflects. The **Reflection**
-agent wakes up while you are not using the system, reviews the day, and
+agent wakes up while you are away from the system, reviews the day, and
 works to be more useful to you tomorrow. It is a scheduled agent like
 any other on the platform, a background job that runs the coding agent
-with a particular brief, except its brief is the instance itself rather
-than any one app.
+with a particular brief, and that brief covers the instance as a whole.
 
-A reflection run does roughly four things, and leaves a one-page morning brief as their output.
+A reflection run leaves a one-page brief after four checks.
 
-**It tidies Memory.** This is the part that is most solid, and it is
-the one I am most confident in because it is the harness move I trust
-most. The nightly run reads the current memory and the day's transcripts and
-produces a _revised_ memory: duplicate notes merged, stale ones
-dropped, scattered observations about the same thing pulled into one
-place, fresh cross-cutting patterns surfaced as new notes. It does not
-edit the transcripts. It rewrites the distilled layer on top of them.
-Tomorrow's agent starts from a memory that is a little cleaner than
-today's, the same way I clean up the agent's instructions between
-sessions in the harness, except no one is driving.
+**It tidies Memory.** I trust this part most, it's the harness move I've
+seen work. The nightly run reads the current memory and the day's
+transcripts and produces a _revised_ memory with duplicate notes merged,
+stale ones dropped, scattered observations about the same thing pulled
+into one place, and fresh cross-cutting patterns surfaced as new notes.
+It leaves the transcripts alone and rewrites the distilled layer on top
+of them. Tomorrow's agent starts from a memory that is a little cleaner
+than today's. The same cleanup I do between harness sessions now runs on
+its own schedule.
 
 **It anticipates what you will need next.** Having read the day, the
-nightly run can notice a pattern and get ahead of it. If you have been logging
-workouts every morning, it can prime the things that make tomorrow's log
-instant. If you keep asking the same kind of question, it can note that
-a small tool would answer it for you. This is the part that feels like
-the agent thinking about you while you are asleep, and it is also the
-part I would describe most carefully. Noticing patterns and writing
-notes is real, while acting on them ahead of time is something the loop
-is built to do but does cautiously, because a system that rearranges
-your morning based on a guess is worse than one that waits to be asked.
+nightly run can notice a pattern and get ahead of it. If you have been
+logging workouts every morning, it can prime the things that make
+tomorrow's log instant. If you keep asking the same kind of question, it
+can note that a small tool would answer it for you. I am careful with
+this one because it can sound creepier than it is. Noticing patterns and
+writing notes works today. The loop takes only small, reversible action
+ahead of time, because a system that rearranges your morning based on a
+guess is worse than one that waits to be asked.
 
-**It suggests apps and features worth building.** A reflection run that has seen
-you reach for the same workaround three times can write down "you keep
-doing X by hand; an app would do it for you" and surface that as a
-suggestion the next morning. It does not build the app unattended. The
-build loop is the one from the first post, with you in it, asking the
-clarifying questions and approving the result. The run's job is to
-have the idea and bring it to you, not to ship code into your instance
-overnight.
+**It suggests apps and features worth building.** A reflection run that
+has seen you reach for the same workaround three times can write down
+"you keep doing X by hand; an app would do it for you" and surface that
+as a suggestion the next morning. Actual building stays in the loop from
+the first post, with you asking the clarifying questions and approving
+the result. The run brings you the idea and leaves your code alone.
 
-**It audits your instance for weak spots.** The agent has write access
+**It reviews your instance for weak spots.** The agent has write access
 to its own shell, themes, app source, and schedules, which means it can
-also _review_ all of those. A reflection run can look for a theme rule that hurts
-contrast, a scheduled job that has been failing quietly, an app whose
-data is growing in a way that will bite later, or a place where the
-shell has drifted. This is the most aspirational of the four. The
-hooks are there, the agent can read every one of those surfaces, but the
-audit today is closer to a checklist than the deep self-review I want it
-to become.
+also _read_ all of those. A reflection run can look for a theme rule
+that hurts contrast, a scheduled job that has been failing quietly, an
+app whose data is growing in a way that will bite later, or a place
+where the shell has drifted. This is the weakest piece today. The hooks
+are there and the agent can read every one of those surfaces, but the
+review itself runs closer to a checklist than the deep self-review I want
+it to become.
 
 <figure class="mb-diagram">
   <div class="mb-cycle">
@@ -182,107 +174,114 @@ to become.
 
     <div class="mb-loopback">
       <span class="mb-loopback__glyph">↺</span>
-      <span>each night's tidy-up is the input to the next night's &nbsp;→&nbsp; the memory compounds instead of just growing</span>
+      <span>each night's tidy-up is the input to the next night's &nbsp;→&nbsp; the memory gets cleaner and more useful each night</span>
     </div>
 
   </div>
-  <figcaption>The nightly loop, end to end. The day fills Memory; the nightly run distills it and looks ahead; you wake to a memory that has been tended and a short list of things the agent thinks are worth building or fixing. Nothing irreversible happens without you.</figcaption>
+  <figcaption>The nightly loop, end to end. The day fills Memory, the nightly run distills it and looks ahead, and you wake to a cleaner memory and a short list of things the agent thinks are worth building or fixing. Everything it changes overnight is committed to a history you can walk back, and anything new or risky waits for your yes in the morning.</figcaption>
 </figure>
 
-The reason all of this can run unattended is the philosophy the whole
-series keeps coming back to. Breaking is allowed because it is
-reversible. A reflection run commits its changes to the same git history
-everything else does, so a bad night's reorganization is something you
-can read back and undo, and the input it works from, your transcripts,
-is never touched. The run produces a new memory beside the old one and
-the old one stays recoverable. That is what makes it safe to let an
-agent rewrite its own memory while no one is watching.
+All of this can run unattended because the whole system treats breaking
+as reversible. A reflection run commits its changes to the same git
+history everything else does, so a bad night's reorganization is
+something you can read back and undo, and it never touches the input it
+works from, your transcripts. The run produces a new memory beside the
+old one, and the old one stays recoverable. That is why I can let it
+rewrite memory overnight.
 
-## Reflection is the harness, built in
+## The harness moves inside
 
-If the loop in that last diagram looks familiar, it should. It is the
-harness from the [second post]({{ '/blog/2026/the-self-improvement-harness/' | relative_url }}),
-turned inward.
+The harness from the [second post]({{ '/blog/2026/the-self-improvement-harness/' | relative_url }})
+now runs inside the instance.
 
 In the harness, the developers run a reflect-and-refactor loop on the
 agent by hand. An outer agent watches the inner one work, asks it why it
 did what it did with the transcript still in context, and rewrites its
-instructions between sessions. The two findings that made that loop work
-were that an agent reflecting on its _own_ recent experience self-corrects
-better than a bigger agent reasoning from outside, and that the right
-move is usually to _remove and reorganize_ rules rather than pile on new
-ones, because a memory that only grows competes with itself.
+instructions between sessions. The loop worked because of two findings.
+An agent reflecting on its _own_ recent experience self-corrects better
+than a bigger agent reasoning from outside, and the right move is usually
+to _remove and reorganize_ rules, because a memory that only grows
+competes with itself.
 
-Both of those are exactly what a reflection run does, except the agent runs the
-loop on itself. It reflects on its own day, the transcript right there in
-context, which is the setting where introspection actually beats
-third-party theory of mind. And the core operation is a refactor of an
-existing memory, merge the duplicates, drop the rules that stopped
-firing, surface the pattern that spans several builds, which is the lesson
-that broke the harness loop open in the first place. The harness proved,
-on controlled experiments, that this is the move that compounds. Reflection
-is that move, scheduled, on your instance, on your behalf.
+Reflection uses both findings, with the agent running the loop on itself.
+It reflects on its own day with the transcript right there in context,
+where introspection beat an outside agent's guesswork in my tests. The
+core operation refactors an existing memory by merging duplicates,
+dropping rules that stopped firing, and surfacing patterns that span
+several builds. In the harness experiments, repeated cleanup made later
+runs better. Reflection runs the same move, scheduled, on your instance,
+on your behalf.
+
+Reflection carries only one of the harness's two mechanisms. The harness
+paired an outside agent cross-checking the inner one with the inner
+agent's own introspection. At 3am only the introspection half runs, and
+the agent grounds a self-report in the day it has had. The experiments
+showed that this half does real work, which is why Reflection tidies its
+own memory well. Its review of the rest of the instance is still shallow,
+and the deep self-review still needs a second vantage.
 
 <blockquote class="pull-quote">
 The same reflect-and-refactor loop the developers run by hand now runs on your own instance, against the agent's own memory, on your schedule and your model.
 </blockquote>
 
-There is also a piece of related work that this lines up with cleanly.
-While I was building the harness, Anthropic shipped a primitive called
-Dreams. A dream reads a memory store and past transcripts and
-produces a _new_ store, with duplicates merged and stale entries
-replaced, without touching the input, so a developer can review the
-result and keep or discard it. That is almost exactly the contract the
-nightly loop runs on, the input log left alone, a fresh memory produced
-beside it, the output yours to keep. Möbius's version is self-hosted,
-your own scheduler and model, running on a graph you actually own.
+This nightly loop runs on almost exactly the contract behind Dreams, the
+primitive Anthropic shipped for managed agents while I was building the
+harness. A dream reads a memory store and past transcripts and produces a
+fresh store beside them, with duplicates merged and stale entries
+replaced. The input stays intact, so you can review the result and keep
+or discard it. Möbius runs that contract self-hosted, on your own
+scheduler and model and a graph you own.
 
-That ownership is the point. A self-improving agent running in someone else's cloud means your memory, your patterns, and your nightly review all live on their machine. Here they do not. The nightly run lives in the same single container as the rest of Möbius, reads from `/data` on your server, writes back to it, and never sends any of it anywhere. The agent gets sharper about you specifically, and the record of that is a folder you can read, back up, or delete.
+Here, self-hosting changes the trust model. A self-improving agent in
+someone else's cloud keeps your memory and your nightly review on their
+machine, and Möbius keeps them on yours. The nightly run lives in the same
+container as everything else, reads from `/data` on your server, and
+writes back to it. Your memory and your transcripts stay there. The one
+thing that leaves the box is the prompt context each run sends to whatever
+model you have configured, the same as any chat does, unless you point it
+at a local one. The agent gets sharper about you specifically, and the
+record of that is a folder you can read, back up, or delete.
 
-## What is shipped and what is still shallow
+## What has shipped and what is still shallow
 
-In the spirit of the rest of this series, here is the honest line
-between what works today and what is still a sketch.
+The split today is simple.
 
-Memory is real and shipped. It is a live knowledge graph, the agent
-reads from it at the start of every session, it writes back to it as it
-learns, and the Memory app renders it as a browsable web of notes. The
-three-layer memory it sits in, a curated constitution, an editable set of
-skills, and the graph itself, is the live model on every instance, not a
-prototype.
+Memory is shipping now, a live knowledge graph. The agent reads from
+it at the start of every session, jots lightweight notes as it works, and
+leaves the heavier consolidation to Reflection at night. The Memory app
+renders the whole thing as a browsable web of notes. The three-layer
+memory it sits in, a curated constitution, an editable set of skills, and
+the graph itself, is the live model on every instance.
 
-Reflection is real and shipped as a scheduled agent, and the first of its
-four jobs, tidying Memory, is the one that genuinely works. The other
-three exist along a spectrum. Anticipating your needs is mostly
-note-taking today; it observes and records well, and acts ahead of time
-only in small, reversible ways. Suggesting apps is wired but quiet, and
-gets better the more the agent has seen you do. The instance audit is the
-most aspirational, the agent can read every surface it would need to
-review, but the review itself is shallow and is where I am spending
-effort next.
+Reflection is shipping now as a scheduled agent, and the first of its
+four jobs, tidying Memory, is the strongest one. The other three are
+uneven. Anticipating your needs is mostly note-taking today; it observes
+and records well, and acts ahead of time only in small, reversible ways.
+Suggesting apps is wired but quiet, and gets better the more the agent
+has seen you do. The instance audit is the least mature. The agent can
+read every surface it would need to review, but the review itself is
+shallow, and that is where I am spending effort next.
 
-I would rather tell you that than pretend the whole nightly loop is
-already the thing I am describing. The architecture is built so that as
-each of those jobs deepens, it does so on the same safe footing: read
-the day, propose a change beside the old state, commit it to a history
-you can walk back. Getting them deep is the work. The loop they run in
-is done.
+I would rather tell you that than pretend the whole nightly loop already
+does everything described here. Each job uses the same reversible
+workflow as it gets deeper. It reads the day, proposes a change beside
+the old state, and commits it to a history you can walk back. The
+remaining work is depth; the loop itself is already running.
 
 ## Where this goes
 
-The arc of this series has been one agent doing one job, getting more of
-itself over time. The first post gave it the ability to build. The
-second gave the developers a loop to make it build well. The third gave
-you the same reshaping power over an app store and the system around it.
-This one closes the loop by handing the _improvement_ itself to your
-instance. The agent that builds your tools now also tends its own memory
-of how to build them, on your server, while you sleep.
+Across the series, the agent has moved outward from building tools into
+maintaining the system around them. The first three posts added
+capability, tooling, and a reshaping mechanism for the app store. This
+post moves the _improvement_ loop itself onto your instance. The agent
+that builds your tools now also tends its own memory of how to build
+them, on your server, while you sleep.
 
-That is the version of a personal assistant I actually want. Not one
-that gets more generic the longer you use it, tuned to keep you engaged,
-its memory of you locked in someone else's cloud. One that gets more
-yours, that improves itself in the direction of being useful to you
-specifically, and that keeps every trace of that on hardware you own.
+I actually want this version of a personal assistant. Most of them get
+more generic the longer you use them, tuned to keep you engaged, with
+their memory of you locked in someone else's cloud. I want one that
+learns your preferences and keeps that record where you can inspect it,
+on hardware you own.
 
 [Möbius]({{ '/mobius/' | relative_url }}) is a deploy-button click away,
 the source is on [GitHub](https://github.com/mobius-os/mobius), and the

--- a/_posts/2026-06-10-your-agent-improves-itself.md
+++ b/_posts/2026-06-10-your-agent-improves-itself.md
@@ -39,9 +39,9 @@ through scenarios, ask it why it did what it did, and rewrite its
 instructions between sessions. That loop lives outside your instance, and
 you never see it. I want to talk now about the version of that loop that
 runs _inside_ your instance, on your data, on your schedule, with the
-agent watching its own work. You go to bed, and your copy of Möbius
-spends part of the night trying to be a little more useful to you by
-morning.
+agent watching its own work. You go to bed, and overnight your instance
+does a pass over the day's work so it is in better shape when you wake
+up.
 
 Two pieces make that work: a memory worth improving and a loop that keeps
 improving it.
@@ -70,8 +70,8 @@ doing that job _for you_. A note might say that a certain compile step
 fails silently if you skip a flag, or that the offline cache needs
 priming a particular way, or that when you say "make it cleaner" you
 usually mean denser rather than more whitespace. The first two are
-platform craft. The third is about you, and the agent keeps it the way a
-good collaborator remembers how you like things.
+platform craft. The third is about you, and the agent holds onto that
+so it does not have to relearn it next time.
 
 <figure class="mb-diagram">
   <div class="mb-flow">
@@ -93,8 +93,8 @@ it. The **Memory** app, one of the starter-pack apps from the
 [last post]({{ '/blog/2026/an-app-store-that-adapts-to-you/' | relative_url }}),
 renders it as an Obsidian-style web of nodes and links. You can open it,
 see what the agent thinks it knows, follow a thread from one lesson to a
-related one, and read any note in full. The notes are a folder you own,
-and the app is a window onto it.
+related one, and read any note in full. The notes are just a folder of
+markdown on your server, and the Memory app is a viewer for it.
 
 This answers the itch I described at the end of the harness post. The
 old experience file was a flat log that only grew. It accreted and never
@@ -106,12 +106,12 @@ Reflection handles that part.
 ## Reflection keeps it fresh
 
 Every night, on a schedule you set, Möbius reflects. The **Reflection**
-agent wakes up while you are away from the system, reviews the day, and
-works to be more useful to you tomorrow. It is a scheduled agent like
+agent runs while you are away, reads back over the day, and tidies what
+the agent learned before the next morning. It is a scheduled agent like
 any other on the platform, a background job that runs the coding agent
 with a particular brief, and that brief covers the instance as a whole.
 
-A reflection run leaves a one-page brief after four checks.
+A reflection run does four things, then leaves a one-page brief.
 
 **It tidies Memory.** I trust this part most, it's the harness move I've
 seen work. The nightly run reads the current memory and the day's
@@ -277,11 +277,10 @@ post moves the _improvement_ loop itself onto your instance. The agent
 that builds your tools now also tends its own memory of how to build
 them, on your server, while you sleep.
 
-I actually want this version of a personal assistant. Most of them get
-more generic the longer you use them, tuned to keep you engaged, with
-their memory of you locked in someone else's cloud. I want one that
-learns your preferences and keeps that record where you can inspect it,
-on hardware you own.
+I actually want this kind of assistant. Most of them drift toward
+generic as you use them, and whatever they remember about you sits in
+someone else's cloud. I want one that learns your preferences and keeps
+that record where you can inspect it, on hardware you own.
 
 [Möbius]({{ '/mobius/' | relative_url }}) is a deploy-button click away,
 the source is on [GitHub](https://github.com/mobius-os/mobius), and the

--- a/_projects/mobius.md
+++ b/_projects/mobius.md
@@ -55,22 +55,27 @@ category: software
 </style>
 
 <p class="lead">
-  <strong>Möbius</strong> is a personal AI agent you self-host whose
-  one job is to be as useful to you as it can. It actively helps by
-  building the tools you ask for as small apps right next to the chat
-  (a news aggregator, a habit tracker, a 3D ISS viewer) without a page
+  A Möbius strip is a surface with no inside or outside and no
+  beginning or end. That is the idea behind <strong>Möbius</strong>, a
+  self-improving personal AI agent you self-host that loops back on
+  itself, with the agent, the server it runs on, and the apps it builds
+  working as one system to be as useful to you as it can. Ask for a
+  tool and the coding agent builds it as a small app right next to the
+  chat (a news aggregator, a habit tracker, a 3D ISS viewer), no page
   reload. Each app can store data, run on a schedule, fetch from the
-  web, and use AI on its own. The same coding agent can also rewrite
-  the interface those apps sit in, from theme and layout to shell
-  features.
+  web, and use AI on its own, and the same agent can rewrite the
+  interface those apps sit in, from theme and layout to the controls
+  around them.
 </p>
 
 <p class="mt-3 mb-4">
   It runs in a single Docker container, comes with a starter app store,
   installs to your phone like a native app, and keeps your data on a
-  server you control. Over time, the Memory and Reflection loop give it a
-  memory to improve from, although the deeper self-audit pieces are
-  still shallow.
+  server you control. Fully recursive self-improvement is not here yet,
+  a person stays in the loop. What works today is the agent and you
+  improving it together, with the Memory and Reflection loop giving it
+  a memory to build from, though the deeper self-audit pieces are still
+  shallow.
 </p>
 
 <figure class="shot-row shot-row--flow" style="margin: 1.75rem auto 0.4rem;">


### PR DESCRIPTION
Reworks the four-post Möbius series for honesty, voice, and a clearer through-line, and updates the `/mobius` project page to match.

## Storyline + framing
- **Etymology intro.** Post 1 now opens by explaining what a Möbius strip is (a surface with no inside or outside and no beginning or end) and using that as the loose idea behind the agent, rather than a buried mid-post mention.
- **Identity.** Foreground "self-improving personal AI agent" on the project page; name the agent + server + app-ecosystem as one system.
- **Honest edge.** State the recursive-self-improvement-isn't-here / human-and-agent-improvement-is-here distinction plainly (Post 2 intro + project page).

## Accuracy (final Claude + Codex review)
- Note that the harness scorecard numbers come from private test sessions, not the public repo.
- Scope the `mobius.json` manifest claim to *published* apps (local apps need none).
- Fix the Post 2 → Post 4 "Reflection app" cross-link (was pointing at Post 3).
- Make the compliance scale consistent (`0–12`, matching the callout + scorecard table).
- Correct the "bring your own account" line (OAuth sign-in, not an API key).

## Voice
- Scrub residual AI tells flagged by the reviewers (negative parallelism, "cuts both ways", rule-of-three closers, inflated metaphor). 0 em-dashes across all four posts.

Built locally (Docker / al-folio image); all four posts render, diagrams intact, prettier-clean.